### PR TITLE
[JENKINS-53445] Catch unknown JVM version

### DIFF
--- a/src/main/java/hudson/plugin/versioncolumn/JVMConstants.java
+++ b/src/main/java/hudson/plugin/versioncolumn/JVMConstants.java
@@ -12,6 +12,7 @@ class JVMConstants {
     public static final int JAVA_9 = 53;
     public static final int JAVA_10 = 54;
     public static final int JAVA_11 = 55;
+    public static final int JAVA_12 = 56;
 
     static final Map<String, Integer> JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING = new LinkedHashMap<String, Integer>();
 
@@ -34,5 +35,7 @@ class JVMConstants {
         JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.put("10.0", JAVA_10);
         JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.put("11", JAVA_11);
         JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.put("11.0", JAVA_11);
+        JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.put("12", JAVA_12);
+        JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.put("12.0", JAVA_12);
     }
 }

--- a/src/main/java/hudson/plugin/versioncolumn/JVMConstants.java
+++ b/src/main/java/hudson/plugin/versioncolumn/JVMConstants.java
@@ -10,6 +10,8 @@ class JVMConstants {
     public static final int JAVA_7 = 51;
     public static final int JAVA_8 = 52;
     public static final int JAVA_9 = 53;
+    public static final int JAVA_10 = 54;
+    public static final int JAVA_11 = 55;
 
     static final Map<String, Integer> JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING = new LinkedHashMap<String, Integer>();
 
@@ -27,5 +29,10 @@ class JVMConstants {
         JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.put("8", JAVA_8);
         JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.put("1.9", JAVA_9);
         JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.put("9", JAVA_9);
+        JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.put("9.0", JAVA_9);
+        JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.put("10", JAVA_10);
+        JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.put("10.0", JAVA_10);
+        JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.put("11", JAVA_11);
+        JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.put("11.0", JAVA_11);
     }
 }

--- a/src/main/java/hudson/plugin/versioncolumn/JVMVersionComparator.java
+++ b/src/main/java/hudson/plugin/versioncolumn/JVMVersionComparator.java
@@ -91,9 +91,16 @@ class JVMVersionComparator {
 
     private boolean isAgentRuntimeCompatibleWithJenkinsBytecodeLevel(String agentMajorMinorVersion) {
         Integer masterBytecodeLevel = getMasterBytecodeMajorVersionNumber();
-        Integer agentVMMaxBytecodeLevel = JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.get(agentMajorMinorVersion);
-
-        return masterBytecodeLevel <= agentVMMaxBytecodeLevel;
+        try {
+            Integer agentVMMaxBytecodeLevel = JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.get(agentMajorMinorVersion);
+            return masterBytecodeLevel <= agentVMMaxBytecodeLevel;
+        } catch(NullPointerException e) {
+            LOGGER.log(Level.WARNING, Messages.JVMVersionMonitor_UnrecognizedAgentJVM(agentMajorMinorVersion));
+            /*
+             * Even if the version might be compatible, we still mark the node as incompatible to prevent potential issues.
+             */
+            return false;
+        }
     }
 
     public boolean isCompatible() {

--- a/src/main/java/hudson/plugin/versioncolumn/JVMVersionComparator.java
+++ b/src/main/java/hudson/plugin/versioncolumn/JVMVersionComparator.java
@@ -91,10 +91,10 @@ class JVMVersionComparator {
 
     private boolean isAgentRuntimeCompatibleWithJenkinsBytecodeLevel(String agentMajorMinorVersion) {
         Integer masterBytecodeLevel = getMasterBytecodeMajorVersionNumber();
-        try {
-            Integer agentVMMaxBytecodeLevel = JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.get(agentMajorMinorVersion);
+        Integer agentVMMaxBytecodeLevel = JDK_VERSION_NUMBER_TO_BYTECODE_LEVEL_MAPPING.get(agentMajorMinorVersion);
+        if (agentVMMaxBytecodeLevel != null) {
             return masterBytecodeLevel <= agentVMMaxBytecodeLevel;
-        } catch(NullPointerException e) {
+        } else {
             LOGGER.log(Level.WARNING, Messages.JVMVersionMonitor_UnrecognizedAgentJVM(agentMajorMinorVersion));
             /*
              * Even if the version might be compatible, we still mark the node as incompatible to prevent potential issues.

--- a/src/main/resources/hudson/plugin/versioncolumn/Messages.properties
+++ b/src/main/resources/hudson/plugin/versioncolumn/Messages.properties
@@ -8,3 +8,5 @@ JVMVersionMonitor.MarkedOffline=Making {0} offline temporarily due to using an i
 JVMVersionMonitor.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE=Agent runtime must be greater or equal than the Master bytecode level (strongly recommended minimum)
 JVMVersionMonitor.MAJOR_MINOR_MATCH=Agent major.minor must be equal to Master major.minor JVM version (paranoid version)
 JVMVersionMonitor.EXACT_MATCH=Agent JVM version must be exactly the same as Master JVM version (paranoid++ version)
+
+JVMVersionMonitor.UnrecognizedAgentJVM=The agent JVM version {0} is not recognized by the plugin. You might want to open a ticket for the maintainer to complete the compatibility list.

--- a/src/test/java/hudson/plugin/versioncolumn/JVMVersionComparatorTest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/JVMVersionComparatorTest.java
@@ -5,8 +5,11 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.Issue;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnitParamsRunner.class)
@@ -104,4 +107,13 @@ public class JVMVersionComparatorTest {
                                             }).isNotCompatible());
     }
 
+    @Issue("JENKINS-53445")
+    @Test
+    public void shouldNotThrowNPEWhenJVMVersionIsNotRecognized() {
+        JVMVersionComparator jvmVersionComparator =
+              new JVMVersionComparator("99.9", "99.9",
+                    JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE);
+        assertNotNull(jvmVersionComparator);
+        assertFalse(jvmVersionComparator.isCompatible());
+    }
 }


### PR DESCRIPTION
[JENKINS-53445](https://issues.jenkins-ci.org/browse/JENKINS-53445)

Prevents to get an NPE when the JVM version is unknown to the plugin but still marks the node as incompatible if so. 
