### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,14 +65,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>5.8.1</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 
     <repositories>
         <repository>


### PR DESCRIPTION
Amends #64. Now that we are on the latest plugin parent POM, JUnit 5 is already included.