### PR TITLE
Require Java 11 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
-buildPlugin(configurations: [
-  [ platform: "linux", jdk: "8", jenkins: null ],
-  [ platform: "windows", jdk: "8", jenkins: null ],
-  [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'windows', jdk: '11' ],
 ])

--- a/README.adoc
+++ b/README.adoc
@@ -21,48 +21,57 @@ This monitor offers 3 levels of monitoring:
 | Description & Examples
 
 | `Default`
-a| Agent must run a JVM whose **major** version is greater or equal than the one the controller is running (strongly recommended minimum).
+a| Agent must run a JVM whose https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.Version.html[feature-release counter] (e.g., 11 or 17) is *greater than or equal to* that of the controller (strongly recommended minimum).
 
-Even without this plugin, it is **critical** to the health of your Jenkins cluster that the agent JVM major version **match** the controller JVM major version.
+Even without this plugin, it is **critical** to the health of your Jenkins cluster that the feature-release counter of the agent JVM **match** that of the controller.
 
 **Examples**:
 
-* Java 7     agent **will be disconnected** from a Java 8u222 controller
-* Java 8u172 agent will not be disconnected from a Java 8u222 controller
-* Java 8u222 agent will not be disconnected from a Java 8u172 controller
-* Java 8u222 agent will not be disconnected from a Java 8u222 controller
-* Java 11.03 agent will not be disconnected from a Java 8u222 controller
-* Java 8u222 agent **will be disconnected** from a Java 11.03 controller
-* Java 11.03 agent will not be disconnected from a Java 11.04 controller
-* Java 11.04 agent will not be disconnected from a Java 11.04 controller
+* Java 11.0.16  agent will not be disconnected from a Java 11.0.17  controller
+* Java 11.0.17  agent will not be disconnected from a Java 11.0.16  controller
+* Java 11.0.17  agent will not be disconnected from a Java 11.0.17  controller
+* Java 17.0.4   agent will not be disconnected from a Java 11.0.17  controller
+* Java 11.0.17  agent **will be disconnected** from a Java 17.0.4   controller
+* Java 17.0.4   agent will not be disconnected from a Java 17.0.4   controller
+* Java 17.0.4   agent will not be disconnected from a Java 17.0.4.1 controller
+* Java 17.0.4.1 agent will not be disconnected from a Java 17.0.4   controller
+* Java 17.0.4.1 agent will not be disconnected from a Java 17.0.4.1 controller
+* Java 17.0.5+8 agent will not be disconnected from a Java 17.0.5+7 controller
+* Java 17.0.5+7 agent will not be disconnected from a Java 17.0.5+8 controller
 
 | `Paranoid`
-a| Agent must run a JVM whose **major.minor** version is greater or equal to the controller version (avoid issues already seen by users).
+a| Agent must run a JVM whose https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.Version.html[version number] -- including feature-release counter, interim-release counter, update-release counter, and patch-release counter (e.g., 11.0.17 or 17.0.4.1) but _not_ including pre-release and build information (e.g., 11.0.17+8, 11.0.17+8-post-Ubuntu-1ubuntu222.04,19+36, or 20-ea+20-1466) -- is *greater than or equal to* that of the controller.
 
 **Examples**:
 
-* Java 7     agent **will be disconnected** from a Java 8u222 controller
-* Java 8u172 agent **will be disconnected** from a Java 8u222 controller
-* Java 8u222 agent will not be disconnected from a Java 8u172 controller
-* Java 8u222 agent will not be disconnected from a Java 8u222 controller
-* Java 11.03 agent will not be disconnected from a Java 8u222 controller
-* Java 8u222 agent **will be disconnected** from a Java 11.03 controller
-* Java 11.03 agent **will be disconnected** from a Java 11.04 controller
-* Java 11.04 agent will not be disconnected from a Java 11.04 controller
+* Java 11.0.16  agent **will be disconnected** from a Java 11.0.17  controller
+* Java 11.0.17  agent will not be disconnected from a Java 11.0.16  controller
+* Java 11.0.17  agent will not be disconnected from a Java 11.0.17  controller
+* Java 17.0.4   agent will not be disconnected from a Java 11.0.17  controller
+* Java 11.0.17  agent **will be disconnected** from a Java 17.0.4   controller
+* Java 17.0.4   agent will not be disconnected from a Java 17.0.4   controller
+* Java 17.0.4   agent **will be disconnected** from a Java 17.0.4.1 controller
+* Java 17.0.4.1 agent will not be disconnected from a Java 17.0.4   controller
+* Java 17.0.4.1 agent will not be disconnected from a Java 17.0.4.1 controller
+* Java 17.0.5+8 agent will not be disconnected from a Java 17.0.5+7 controller
+* Java 17.0.5+7 agent will not be disconnected from a Java 17.0.5+8 controller
 
 | `Paranoid++`
-a| Agent must run a JVM whose version is *exactly* equal to the controller version (most paranoid option)
+a| Agent must run a JVM whose https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.Version.html[version number] -- including feature-release counter, interim-release counter, update-release counter, and patch-release counter (e.g., 11.0.17 or 17.0.4.1) but _not_ including pre-release and build information (e.g., 11.0.17+8, 11.0.17+8-post-Ubuntu-1ubuntu222.04,19+36, or 20-ea+20-1466) -- is *equal to* that of the controller.
 
 **Examples**:
 
-* Java 7     agent **will be disconnected** from a Java 8u222 controller
-* Java 8u172 agent **will be disconnected** from a Java 8u222 controller
-* Java 8u222 agent **will be disconnected** from a Java 8u172 controller
-* Java 8u222 agent will not be disconnected from a Java 8u222 controller
-* Java 11.03 agent **will be disconnected** from a Java 8u222 controller
-* Java 8u222 agent **will be disconnected** from a Java 11.03 controller
-* Java 11.03 agent **will be disconnected** from a Java 11.04 controller
-* Java 11.04 agent will not be disconnected from a Java 11.04 controller
+* Java 11.0.16  agent **will be disconnected** from a Java 11.0.17  controller
+* Java 11.0.17  agent **will be disconnected** from a Java 11.0.16  controller
+* Java 11.0.17  agent will not be disconnected from a Java 11.0.17  controller
+* Java 17.0.4   agent **will be disconnected** from a Java 11.0.17  controller
+* Java 11.0.17  agent **will be disconnected** from a Java 17.0.4   controller
+* Java 17.0.4   agent will not be disconnected from a Java 17.0.4   controller
+* Java 17.0.4   agent **will be disconnected** from a Java 17.0.4.1 controller
+* Java 17.0.4.1 agent **will be disconnected** from a Java 17.0.4   controller
+* Java 17.0.4.1 agent will not be disconnected from a Java 17.0.4.1 controller
+* Java 17.0.5+8 agent will not be disconnected from a Java 17.0.5+7 controller
+* Java 17.0.5+7 agent will not be disconnected from a Java 17.0.5+8 controller
 
 |===
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,14 +51,14 @@
     <properties>
         <revision>2.3</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.346.1</jenkins.version>
+        <jenkins.version>2.361.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.346.x</artifactId>
+                <artifactId>bom-2.361.x</artifactId>
                 <version>1678.vc1feb_6a_3c0f1</version>
                 <scope>import</scope>
                 <type>pom</type>

--- a/src/main/java/hudson/plugin/versioncolumn/JVMVersionComparator.java
+++ b/src/main/java/hudson/plugin/versioncolumn/JVMVersionComparator.java
@@ -23,94 +23,45 @@
  */
 package hudson.plugin.versioncolumn;
 
-import com.google.common.annotations.VisibleForTesting;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.util.VersionNumber;
-import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
-import jenkins.model.Jenkins;
-import org.apache.commons.codec.binary.Hex;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.jar.JarFile;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.zip.ZipEntry;
-
+import java.util.List;
 
 /**
  * Responsible for controller and agent jvm versions comparisons, and notions of "compatibility".
- * <p>For instance, the default behaviour is to consider 1.8.0 compatible with 1.8.3-whatever and so on.
- * Only considering <em>major.minor</em> part, that is</p>
  */
 class JVMVersionComparator {
 
-    private static final Logger LOGGER = Logger.getLogger(JVMVersionComparator.class.getName());
-
-    private static final Pattern MAJOR_MINOR_PATTERN = Pattern.compile("(\\d+\\.\\d+).*");
-    private final MasterBytecodeMajorVersionNumberGetter masterBytecodeMajorVersionNumberGetter;
     private boolean compatible;
 
-    JVMVersionComparator(String masterVersion, String agentVersion, ComparisonMode comparisonMode) {
-        this(masterVersion, agentVersion, comparisonMode, new MasterBytecodeMajorVersionNumberGetter());
-    }
-
-    @VisibleForTesting
-    JVMVersionComparator(String masterVersion, String agentVersion, ComparisonMode comparisonMode, MasterBytecodeMajorVersionNumberGetter versionNumberGetter) {
-        masterBytecodeMajorVersionNumberGetter = versionNumberGetter;
+    JVMVersionComparator(Runtime.Version controllerVersion, Runtime.Version agentVersion, ComparisonMode comparisonMode) {
         if (ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE == comparisonMode) {
-            compatible = isAgentRuntimeCompatibleWithJenkinsBytecodeLevel(computeMajorMinor(agentVersion));
+            compatible = agentVersion.feature() >= controllerVersion.feature();
         } else if (ComparisonMode.EXACT_MATCH == comparisonMode) {
-            compatible = masterVersion.equals(agentVersion);
+            compatible = controllerVersion.version().equals(agentVersion.version());
         } else if (ComparisonMode.MAJOR_MINOR_MATCH == comparisonMode) {
-            compatible = computeMajorMinor(masterVersion).equals(computeMajorMinor(agentVersion));
+            compatible = compareVersionList(agentVersion.version(), controllerVersion.version()) >= 0;
         }
-    }
-
-    @NonNull
-    @VisibleForTesting
-    static String computeMajorMinor(String version) {
-        final Matcher matcher = MAJOR_MINOR_PATTERN.matcher(version);
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException(version + " is not a supported JVM version pattern");
-        }
-        return matcher.group(1);
     }
 
     /**
-     * Reading the Jenkins.class bytecode first, then fallback to Jenkins.getVersion() is something is wrong.
+     * Compare the {@link Runtime.Version#version()} of two {@link Runtime.Version}s.
      *
-     * @return the bytecode major version of the Jenkins class (example: 51 for Java 7, 52 for Java 8...).
-     * @see <a href="https://en.wikipedia.org/wiki/Java_class_file#General_layout">the Java bytecode general layout</a>.
+     * @param o1 The {@link Runtime.Version#version()} of the first {@link Runtime.Version}.
+     * @param o2 The {@link Runtime.Version#version()} of the seconds {@link Runtime.Version}.
+     * @return A negative integer, zero, or a positive integer if the first {@link
+     *     Runtime.Version#version()} is less than, equal to, or greater than the second {@link
+     *     Runtime.Version#version()}.
      */
-    private int getMasterBytecodeMajorVersionNumber() {
-        return masterBytecodeMajorVersionNumberGetter.get();
-    }
-
-    @SuppressFBWarnings(value = "DCN_NULLPOINTER_EXCEPTION", justification = "JavaSpecificationVersion.fromReleaseVersion needs to be cleaned up to return null rather than throw NPE when an invalid version is passed in")
-    private boolean isAgentRuntimeCompatibleWithJenkinsBytecodeLevel(String agentMajorMinorVersion) {
-        int masterBytecodeLevel = getMasterBytecodeMajorVersionNumber();
-        int agentVMMaxBytecodeLevel;
-        try {
-            int releaseVersion;
-            if (agentMajorMinorVersion.startsWith("1.")) {
-                releaseVersion = Integer.parseInt(agentMajorMinorVersion.split("\\.")[1]);
-            } else {
-                releaseVersion = Integer.parseInt(agentMajorMinorVersion.split("\\.")[0]);
+    private static int compareVersionList(List<Integer> o1, List<Integer> o2) {
+        int size1 = o1.size();
+        int size2 = o2.size();
+        for (int i = 0; i < Math.min(size1, size2); i++) {
+            int value1 = o1.get(i);
+            int value2 = o2.get(i);
+            if (value1 != value2) {
+                return value1 - value2;
             }
-            JavaSpecificationVersion javaSpecificationVersion = JavaSpecificationVersion.fromReleaseVersion(releaseVersion);
-            agentVMMaxBytecodeLevel = javaSpecificationVersion.toClassVersion();
-        } catch (NullPointerException | NumberFormatException e) {
-            LOGGER.log(Level.WARNING, Messages.JVMVersionMonitor_UnrecognizedAgentJVM(agentMajorMinorVersion), e);
-            /*
-             * Even if the version might be compatible, we still mark the node as incompatible to prevent potential issues.
-             */
-            return false;
         }
-        return masterBytecodeLevel <= agentVMMaxBytecodeLevel;
+        return size1 - size2;
     }
 
     public boolean isCompatible() {
@@ -134,56 +85,6 @@ class JVMVersionComparator {
 
         public String getDescription() {
             return description;
-        }
-
-    }
-
-    /**
-     * Delegate exclusively dedicated to testability
-     */
-    @VisibleForTesting
-    static class MasterBytecodeMajorVersionNumberGetter {
-
-        public int get() {
-
-            final URL location = Jenkins.class.getProtectionDomain().getCodeSource().getLocation();
-            try (JarFile jarFile = new JarFile(location.getFile())) {
-                final ZipEntry jenkinsClassEntry = jarFile.getEntry("jenkins/model/Jenkins.class");
-
-                final InputStream inputStream = jarFile.getInputStream(jenkinsClassEntry);
-                byte[] magicAndClassFileVersion = new byte[8];
-
-                int read = inputStream.read(magicAndClassFileVersion);
-                final String hexaBytes = Hex.encodeHexString(magicAndClassFileVersion);
-                LOGGER.log(Level.FINE, "Jenkins.class file 8 first bytes: {0}", hexaBytes);
-                if (read != 8 || !hexaBytes.startsWith("cafebabe")) {
-                    throw new IllegalStateException("Jenkins.class content is abnormal: '" + hexaBytes + "'");
-                }
-                int javaMajor = (magicAndClassFileVersion[6] << 8) & 0xff00 |
-                        magicAndClassFileVersion[7] & 0xff;
-                LOGGER.log(Level.FINEST, "Bytecode major version {0}", javaMajor);
-            } catch (Exception e) {
-                LOGGER.log(Level.SEVERE, "Issue while reading Jenkins.class bytecode level", e);
-            }
-
-            LOGGER.log(Level.FINE, "Falling back to using Jenkins.getVersion to infer bytecode level");
-            VersionNumber jenkinsVersion = Jenkins.getVersion();
-            if (jenkinsVersion == null) {
-                throw new IllegalStateException("Jenkins.getVersion() returned a null value, stopping.");
-            }
-            // So Jenkins started with Java 1.4 (or less?) reading the *old* changelog (like around ~1.100)
-            // but well not sure I'll bother
-            if (jenkinsVersion.isOlderThan(new VersionNumber("1.520"))) {
-                return JavaSpecificationVersion.JAVA_5.toClassVersion();
-            } else if (jenkinsVersion.isOlderThan(new VersionNumber("1.612"))) {
-                return JavaSpecificationVersion.JAVA_6.toClassVersion();
-            } else if (jenkinsVersion.isOlderThan(new VersionNumber("2.54"))) {
-                return JavaSpecificationVersion.JAVA_7.toClassVersion();
-            } else if (jenkinsVersion.isNewerThan(new VersionNumber("2.54"))) {
-                return JavaSpecificationVersion.JAVA_8.toClassVersion();
-            }
-
-            throw new IllegalStateException("Jenkins Bytecode Level could not be inferred");
         }
     }
 }

--- a/src/main/resources/hudson/plugin/versioncolumn/JVMVersionMonitor/help-comparisonMode.html
+++ b/src/main/resources/hudson/plugin/versioncolumn/JVMVersionMonitor/help-comparisonMode.html
@@ -1,75 +1,216 @@
 <div>
-    <p>The goal is to help making sure JVM versions in use on Controller and Agents are <em>reasonably</em> aligned
-        to avoid <code>ClassFormatError</code> and other cool errors.</p>
-    <style>
-        table#jvmversion, table#jvmversion tr,table#jvmversion th,table#jvmversion td {
-            border: 1px solid;
-            border-collapse: collapse;
-        }
+  <p>
+    The goal is to help making sure JVM versions in use on the controller and agents are <em>reasonably</em> aligned to avoid <code>UnsupportedClassVersionError</code> and other low-level Java errors.
+  </p>
+  <style type="text/css">
+    dl#jvmversion {
+      padding: 0;
+    }
 
-    </style>
-    <table id="jvmversion">
-        <thead>
-        <tr>
-            <th>Description</th>
-            <th>Examples</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-            <td><p>Agent runtime must be greater or equal than the Controller bytecode level (strongly recommended minimum)</p></td>
-            <td>
-                <div>
-                    <div>
-                        <ul>
-                            <li>
-                                <p>an agent running Java 6 or less will be disconnected from 2.32.3 Controller</p>
-                            </li>
-                            <li>
-                                <p>an agent running Java 6 will not be disconnected from a 1.609 Controller</p>
-                            </li>
-                            <li>
-                                <p>an agent running Java 7 will be disconnected from a 2.54 Controller</p>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td><p>Agent major.minor must be equal to Controller major.minor JVM version (paranoid version)</p></td>
-            <td>
-                <div>
-                    <div>
-                        <ul>
-                            <li>
-                                <p>an agent running 1.7 or less will be disconnected from a Controller running
-                                    1.8.112</p>
-                            </li>
-                            <li>
-                                <p>an agent running 1.8.66 will not be disconnected from a Controller running
-                                    1.8.112</p>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td><p>Agent JVM version must be exactly the same as Controller JVM version (paranoid++ version)</p></td>
-            <td>
-                <div>
-                    <div>
-                        <ul>
-                            <li>
-                                <p>an agent running 1.8.66 will be disconnected from a Controller running 1.8.112</p>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </td>
-        </tr>
-        </tbody>
-    </table>
+    dl#jvmversion dt {
+      padding: 0;
+      margin-top: 1em;
+      margin-bottom: 0.3em;
+      font-weight: normal;
+    }
 
+    dl#jvmversion dd {
+      padding: 0;
+      margin-bottom: 1em;
+    }
+  </style>
+  <dl id="jvmversion">
+    <dt>
+      <p>
+        Agent must run a JVM whose <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.Version.html">feature-release counter</a> (e.g., 11 or 17) is <strong>greater than or equal to</strong> that of the controller (strongly recommended minimum)
+      </p>
+    </dt>
+    <dd>
+      <ul>
+        <li>
+          <p>
+            Java 11.0.16 agent will not be disconnected from a Java 11.0.17 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 11.0.17 agent will not be disconnected from a Java 11.0.16 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 11.0.17 agent will not be disconnected from a Java 11.0.17 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4 agent will not be disconnected from a Java 11.0.17 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 11.0.17 agent <strong>will be disconnected</strong> from a Java 17.0.4 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4 agent will not be disconnected from a Java 17.0.4 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4 agent will not be disconnected from a Java 17.0.4.1 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4.1 agent will not be disconnected from a Java 17.0.4 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4.1 agent will not be disconnected from a Java 17.0.4.1 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.5+8 agent will not be disconnected from a Java 17.0.5+7 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.5+7 agent will not be disconnected from a Java 17.0.5+8 controller
+          </p>
+        </li>
+      </ul>
+    </dd>
+    <dt>
+      <p>
+        Agent must run a JVM whose <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.Version.html">version number</a> &#8212; including feature-release counter, interim-release counter, update-release counter, and patch-release counter (e.g., 11.0.17 or 17.0.4.1) but _not_ including pre-release and build information (e.g., 11.0.17+8, 11.0.17+8-post-Ubuntu-1ubuntu222.04,19+36, or 20-ea+20-1466) &#8212; is <strong>greater than or equal to</strong> that of the controller (paranoid version)
+      </p>
+    </dt>
+    <dd>
+      <ul>
+        <li>
+          <p>
+            Java 11.0.16 agent <strong>will be disconnected</strong> from a Java 11.0.17 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 11.0.17 agent will not be disconnected from a Java 11.0.16 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 11.0.17 agent will not be disconnected from a Java 11.0.17 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4 agent will not be disconnected from a Java 11.0.17 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 11.0.17 agent <strong>will be disconnected</strong> from a Java 17.0.4 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4 agent will not be disconnected from a Java 17.0.4 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4 agent <strong>will be disconnected</strong> from a Java 17.0.4.1 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4.1 agent will not be disconnected from a Java 17.0.4 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4.1 agent will not be disconnected from a Java 17.0.4.1 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.5+8 agent will not be disconnected from a Java 17.0.5+7 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.5+7 agent will not be disconnected from a Java 17.0.5+8 controller
+          </p>
+        </li>
+      </ul>
+    </dd>
+    <dt>
+      <p>
+        Agent must run a JVM whose <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.Version.html">version number</a> &#8212; including feature-release counter, interim-release counter, update-release counter, and patch-release counter (e.g., 11.0.17 or 17.0.4.1) but _not_ including pre-release and build information (e.g., 11.0.17+8, 11.0.17+8-post-Ubuntu-1ubuntu222.04,19+36, or 20-ea+20-1466) &#8212; is <strong>equal to</strong> that of the controller (paranoid++ version)
+      </p>
+    </dt>
+    <dd>
+      <ul>
+        <li>
+          <p>
+            Java 11.0.16 agent <strong>will be disconnected</strong> from a Java 11.0.17 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 11.0.17 agent <strong>will be disconnected</strong> from a Java 11.0.16 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 11.0.17 agent will not be disconnected from a Java 11.0.17 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4 agent <strong>will be disconnected</strong> from a Java 11.0.17 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 11.0.17 agent <strong>will be disconnected</strong> from a Java 17.0.4 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4 agent will not be disconnected from a Java 17.0.4 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4 agent <strong>will be disconnected</strong> from a Java 17.0.4.1 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4.1 agent <strong>will be disconnected</strong> from a Java 17.0.4 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.4.1 agent will not be disconnected from a Java 17.0.4.1 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.5+8 agent will not be disconnected from a Java 17.0.5+7 controller
+          </p>
+        </li>
+        <li>
+          <p>
+            Java 17.0.5+7 agent will not be disconnected from a Java 17.0.5+8 controller
+          </p>
+        </li>
+      </ul>
+    </dd>
+  </dl>
 </div>

--- a/src/main/resources/hudson/plugin/versioncolumn/JVMVersionMonitor/help-comparisonMode.html
+++ b/src/main/resources/hudson/plugin/versioncolumn/JVMVersionMonitor/help-comparisonMode.html
@@ -86,7 +86,7 @@
     </dd>
     <dt>
       <p>
-        Agent must run a JVM whose <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.Version.html">version number</a> &#8212; including feature-release counter, interim-release counter, update-release counter, and patch-release counter (e.g., 11.0.17 or 17.0.4.1) but _not_ including pre-release and build information (e.g., 11.0.17+8, 11.0.17+8-post-Ubuntu-1ubuntu222.04,19+36, or 20-ea+20-1466) &#8212; is <strong>greater than or equal to</strong> that of the controller (paranoid version)
+        Agent must run a JVM whose <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.Version.html">version number</a> &#8212; including feature-release counter, interim-release counter, update-release counter, and patch-release counter (e.g., 11.0.17 or 17.0.4.1) but <em>not</em> including pre-release and build information (e.g., 11.0.17+8, 11.0.17+8-post-Ubuntu-1ubuntu222.04,19+36, or 20-ea+20-1466) &#8212; is <strong>greater than or equal to</strong> that of the controller (paranoid version)
       </p>
     </dt>
     <dd>
@@ -150,7 +150,7 @@
     </dd>
     <dt>
       <p>
-        Agent must run a JVM whose <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.Version.html">version number</a> &#8212; including feature-release counter, interim-release counter, update-release counter, and patch-release counter (e.g., 11.0.17 or 17.0.4.1) but _not_ including pre-release and build information (e.g., 11.0.17+8, 11.0.17+8-post-Ubuntu-1ubuntu222.04,19+36, or 20-ea+20-1466) &#8212; is <strong>equal to</strong> that of the controller (paranoid++ version)
+        Agent must run a JVM whose <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.Version.html">version number</a> &#8212; including feature-release counter, interim-release counter, update-release counter, and patch-release counter (e.g., 11.0.17 or 17.0.4.1) but <em>not</em> including pre-release and build information (e.g., 11.0.17+8, 11.0.17+8-post-Ubuntu-1ubuntu222.04,19+36, or 20-ea+20-1466) &#8212; is <strong>equal to</strong> that of the controller (paranoid++ version)
       </p>
     </dt>
     <dd>

--- a/src/main/resources/hudson/plugin/versioncolumn/Messages.properties
+++ b/src/main/resources/hudson/plugin/versioncolumn/Messages.properties
@@ -5,8 +5,8 @@ VersionMonitor.MarkedOffline=Making {0} offline temporarily due to the use of an
 JVMVersionMonitor.DisplayName=JVM Version
 JVMVersionMonitor.OfflineCause=This node is offline because the JVM version of the agent is incompatible with the controller one.
 JVMVersionMonitor.MarkedOffline=Making {0} offline temporarily due to using an incompatible JVM version between agent and controller (controller={1}, agent={2})
-JVMVersionMonitor.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE=Agent runtime must be greater or equal than the controller bytecode level (strongly recommended minimum)
-JVMVersionMonitor.MAJOR_MINOR_MATCH=Agent major.minor must be equal to controller major.minor JVM version (paranoid version)
-JVMVersionMonitor.EXACT_MATCH=Agent JVM version must be exactly the same as controller JVM version (paranoid++ version)
+JVMVersionMonitor.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE=Agent must run a JVM whose feature-release counter (e.g., 11 or 17) is greater than or equal to that of the controller (strongly recommended minimum)
+JVMVersionMonitor.MAJOR_MINOR_MATCH=Agent must run a JVM whose version number (e.g., 11.0.17 or 17.0.4.1) is greater than or equal to that of the controller (paranoid version)
+JVMVersionMonitor.EXACT_MATCH=Agent must run a JVM whose version number (e.g., 11.0.17 or 17.0.4.1) is equal to that of the controller (paranoid++ version)
 
 JVMVersionMonitor.UnrecognizedAgentJVM=The agent JVM version {0} is not recognized by the plugin. You might want to open a ticket for the maintainer to complete the compatibility list.

--- a/src/test/java/hudson/plugin/versioncolumn/JVMVersionComparatorTest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/JVMVersionComparatorTest.java
@@ -1,121 +1,55 @@
 package hudson.plugin.versioncolumn;
 
-import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
-import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.jvnet.hudson.test.Issue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JVMVersionComparatorTest {
 
-    @Test
-    public void computeMajorMinor() {
-        assertEquals("1.8", JVMVersionComparator.computeMajorMinor("1.8.0"));
-        assertEquals("1.8", JVMVersionComparator.computeMajorMinor("1.8.0_66"));
-        assertEquals("1.8", JVMVersionComparator.computeMajorMinor("1.8.1-blah_whatever$wat"));
-    }
-
-    private static Object[] parametersForCompatible() {
-        return new Object[][]{
-                {"1.8.0", "1.8.0", true},
-                {"11.0.11", "11.0.11", true},
-                {"1.8.0", "1.8.0", false},
-                {"1.6.0", "1.6.0", true},
-                {"1.6.0", "1.6.1_ublah_whatever", false},
-                {"1.8.066", "1.8.0110", false},
-        };
-    }
-
-    private static Object[] parametersForIncompatible() {
-        return new Object[][]{
-                {"1.5.0", "1.5.1", true},
-                {"1.7.0", "1.6.0", true},
-                {"1.7.0", "11.0.2", true},
-                {"17.0.3", "11.0.2", true},
-                {"1.8.0_66", "1.8.0_110", true},
-                {"1.6.0", "1.6.1", true},
+    private static Object[] parameters() {
+        return new Object[][] {
+            {
+                "11.0.16", "11.0.17", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+                "11.0.17", "11.0.16", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+                "11.0.17", "11.0.17", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+                "17.0.4", "11.0.17", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+                "11.0.17", "17.0.4", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, false,
+                "17.0.4", "17.0.4", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+                "17.0.4", "17.0.4.1", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+                "17.0.4.1", "17.0.4", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+                "17.0.4.1", "17.0.4.1", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+                "17.0.5+8", "17.0.5+7", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+                "17.0.5+7", "17.0.5+8", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+                "11.0.16", "11.0.17", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, false,
+                "11.0.17", "11.0.16", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+                "11.0.17", "11.0.17", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+                "17.0.4", "11.0.17", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+                "11.0.17", "17.0.4", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, false,
+                "17.0.4", "17.0.4", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+                "17.0.4", "17.0.4.1", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, false,
+                "17.0.4.1", "17.0.4", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+                "17.0.4.1", "17.0.4.1", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+                "17.0.5+8", "17.0.5+7", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+                "17.0.5+7", "17.0.5+8", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+                "11.0.16", "11.0.17", JVMVersionComparator.ComparisonMode.EXACT_MATCH, false,
+                "11.0.17", "11.0.16", JVMVersionComparator.ComparisonMode.EXACT_MATCH, false,
+                "11.0.17", "11.0.17", JVMVersionComparator.ComparisonMode.EXACT_MATCH, true,
+                "17.0.4", "11.0.17", JVMVersionComparator.ComparisonMode.EXACT_MATCH, false,
+                "11.0.17", "17.0.4", JVMVersionComparator.ComparisonMode.EXACT_MATCH, false,
+                "17.0.4", "17.0.4", JVMVersionComparator.ComparisonMode.EXACT_MATCH, true,
+                "17.0.4", "17.0.4.1", JVMVersionComparator.ComparisonMode.EXACT_MATCH, false,
+                "17.0.4.1", "17.0.4", JVMVersionComparator.ComparisonMode.EXACT_MATCH, false,
+                "17.0.4.1", "17.0.4.1", JVMVersionComparator.ComparisonMode.EXACT_MATCH, true,
+                "17.0.5+8", "17.0.5+7", JVMVersionComparator.ComparisonMode.EXACT_MATCH, true,
+                "17.0.5+7", "17.0.5+8", JVMVersionComparator.ComparisonMode.EXACT_MATCH, true,
+            }
         };
     }
 
     @ParameterizedTest
-    @MethodSource("parametersForCompatible")
-    public void compatible(String masterVersion, String agentVersion, boolean exactMatch) {
-        JVMVersionComparator.ComparisonMode comparisonMode = toExactMatch(exactMatch);
-        assertTrue(new JVMVersionComparator(masterVersion, agentVersion, comparisonMode).isCompatible());
-    }
-
-    @ParameterizedTest
-    @MethodSource("parametersForIncompatible")
-    public void incompatible(String masterVersion, String agentVersion, boolean exactMatch) {
-        JVMVersionComparator.ComparisonMode comparisonMode = toExactMatch(exactMatch);
-        assertTrue(new JVMVersionComparator(masterVersion, agentVersion, comparisonMode).isNotCompatible());
-    }
-
-    private JVMVersionComparator.ComparisonMode toExactMatch(boolean exactMatch) {
-        if (exactMatch) {
-            return JVMVersionComparator.ComparisonMode.EXACT_MATCH;
-        } else {
-            return JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH;
-        }
-    }
-
-    private static Object[] parametersForCompatibleBytecodeLevel() {
-        return new Object[][]{
-                {"1.8.0", JavaSpecificationVersion.JAVA_8.toClassVersion()},
-                {"1.8.0", JavaSpecificationVersion.JAVA_7.toClassVersion()},
-                {"1.8.0", JavaSpecificationVersion.JAVA_6.toClassVersion()},
-                {"11.0.1", JavaSpecificationVersion.JAVA_11.toClassVersion()},
-        };
-    }
-
-    private static Object[] parametersForIncompatibleBytecodeLevel() {
-        return new Object[][]{
-                {"1.7.0", JavaSpecificationVersion.JAVA_8.toClassVersion()},
-                {"1.6.1", JavaSpecificationVersion.JAVA_7.toClassVersion()},
-                {"1.5.3", JavaSpecificationVersion.JAVA_6.toClassVersion()},
-                {"11.0.3", JavaSpecificationVersion.JAVA_12.toClassVersion()},
-        };
-    }
-
-
-    @ParameterizedTest
-    @MethodSource("parametersForCompatibleBytecodeLevel")
-    public void compatibleBytecodeLevel(String agentVMVersion, final int masterBytecodeMajorVersion) {
-        assertTrue(new JVMVersionComparator("whatever", agentVMVersion,
-                                            JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE,
-                                            new JVMVersionComparator.MasterBytecodeMajorVersionNumberGetter() {
-                                                @Override
-                                                public int get() {
-                                                    return masterBytecodeMajorVersion;
-                                                }
-                                            }).isCompatible());
-    }
-
-    @ParameterizedTest
-    @MethodSource("parametersForIncompatibleBytecodeLevel")
-    public void incompatibleBytecodeLevel(String agentVMVersion, final int masterBytecodeMajorVersion) {
-        assertTrue(new JVMVersionComparator("whatever", agentVMVersion,
-                                            JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE,
-                                            new JVMVersionComparator.MasterBytecodeMajorVersionNumberGetter() {
-                                                @Override
-                                                public int get() {
-                                                    return masterBytecodeMajorVersion;
-                                                }
-                                            }).isNotCompatible());
-    }
-
-    @Issue("JENKINS-53445")
-    @Test
-    public void shouldNotThrowNPEWhenJVMVersionIsNotRecognized() {
-        JVMVersionComparator jvmVersionComparator =
-              new JVMVersionComparator("99.9", "99.9",
-                    JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE);
-        assertNotNull(jvmVersionComparator);
-        assertFalse(jvmVersionComparator.isCompatible());
+    @MethodSource("parameters")
+    public void smokes(String controllerVersion, String agentVersion, JVMVersionComparator.ComparisonMode comparisonMode, boolean isCompatible) {
+        assertEquals(isCompatible, new JVMVersionComparator(Runtime.Version.parse(controllerVersion), Runtime.Version.parse(agentVersion), comparisonMode).isCompatible());
     }
 }

--- a/src/test/java/hudson/plugin/versioncolumn/JVMVersionComparatorTest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/JVMVersionComparatorTest.java
@@ -11,45 +11,109 @@ public class JVMVersionComparatorTest {
         return new Object[][] {
             {
                 "11.0.16", "11.0.17", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+            },
+            {
                 "11.0.17", "11.0.16", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+            },
+            {
                 "11.0.17", "11.0.17", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+            },
+            {
                 "17.0.4", "11.0.17", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+            },
+            {
                 "11.0.17", "17.0.4", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, false,
+            },
+            {
                 "17.0.4", "17.0.4", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+            },
+            {
                 "17.0.4", "17.0.4.1", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+            },
+            {
                 "17.0.4.1", "17.0.4", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+            },
+            {
                 "17.0.4.1", "17.0.4.1", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+            },
+            {
                 "17.0.5+8", "17.0.5+7", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+            },
+            {
                 "17.0.5+7", "17.0.5+8", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
+            },
+            {
                 "11.0.16", "11.0.17", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, false,
+            },
+            {
                 "11.0.17", "11.0.16", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+            },
+            {
                 "11.0.17", "11.0.17", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+            },
+            {
                 "17.0.4", "11.0.17", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+            },
+            {
                 "11.0.17", "17.0.4", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, false,
+            },
+            {
                 "17.0.4", "17.0.4", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+            },
+            {
                 "17.0.4", "17.0.4.1", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, false,
+            },
+            {
                 "17.0.4.1", "17.0.4", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+            },
+            {
                 "17.0.4.1", "17.0.4.1", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+            },
+            {
                 "17.0.5+8", "17.0.5+7", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+            },
+            {
                 "17.0.5+7", "17.0.5+8", JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, true,
+            },
+            {
                 "11.0.16", "11.0.17", JVMVersionComparator.ComparisonMode.EXACT_MATCH, false,
+            },
+            {
                 "11.0.17", "11.0.16", JVMVersionComparator.ComparisonMode.EXACT_MATCH, false,
+            },
+            {
                 "11.0.17", "11.0.17", JVMVersionComparator.ComparisonMode.EXACT_MATCH, true,
+            },
+            {
                 "17.0.4", "11.0.17", JVMVersionComparator.ComparisonMode.EXACT_MATCH, false,
+            },
+            {
                 "11.0.17", "17.0.4", JVMVersionComparator.ComparisonMode.EXACT_MATCH, false,
+            },
+            {
                 "17.0.4", "17.0.4", JVMVersionComparator.ComparisonMode.EXACT_MATCH, true,
+            },
+            {
                 "17.0.4", "17.0.4.1", JVMVersionComparator.ComparisonMode.EXACT_MATCH, false,
+            },
+            {
                 "17.0.4.1", "17.0.4", JVMVersionComparator.ComparisonMode.EXACT_MATCH, false,
+            },
+            {
                 "17.0.4.1", "17.0.4.1", JVMVersionComparator.ComparisonMode.EXACT_MATCH, true,
+            },
+            {
                 "17.0.5+8", "17.0.5+7", JVMVersionComparator.ComparisonMode.EXACT_MATCH, true,
+            },
+            {
                 "17.0.5+7", "17.0.5+8", JVMVersionComparator.ComparisonMode.EXACT_MATCH, true,
-            }
+            },
         };
     }
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void smokes(String controllerVersion, String agentVersion, JVMVersionComparator.ComparisonMode comparisonMode, boolean isCompatible) {
+    public void smokes(String agentVersion, String controllerVersion, JVMVersionComparator.ComparisonMode comparisonMode, boolean isCompatible) {
         assertEquals(isCompatible, new JVMVersionComparator(Runtime.Version.parse(controllerVersion), Runtime.Version.parse(agentVersion), comparisonMode).isCompatible());
     }
 }


### PR DESCRIPTION
This PR effectively rewrites this plugin from scratch, dropping support for Java 8 and earlier and relying on the native Java Platform `Runtime.Version` class, which has new semantics. All documentation and examples are updated to refer to the new semantics. Compatibility is retained. I spot-checked the UI in my browser and am confident of the behavior based on the unit tests. If you're interested in doing some functional testing that could not hurt, but I don't think it is critical based on how simple the logic is and how high the unit test coverage is.

CC @MarkEWaite 