### PR TITLE
[JENKINS-70069] Add help to remoting version checkbox

### DIFF
--- a/src/main/resources/hudson/plugin/versioncolumn/VersionMonitor/help.html
+++ b/src/main/resources/hudson/plugin/versioncolumn/VersionMonitor/help.html
@@ -1,0 +1,10 @@
+<div>
+  When enabled, this monitor will disconnect agents that are not running the <strong>same version</strong> of remoting as the version on the Jenkins controller.
+  This monitor does not provide any concept of compatibility between remoting versions.
+  <p>
+  <a href="https://github.com/jenkinsci/remoting/#readme">Jenkins remoting</a> implements the communication layer between Jenkins controllers and Jenkins agents.
+  Recent remoting versions are generally compatible with one another.
+  This check enforces a more strict requirement that the remoting version on the agent must exactly match the remoting version on the controller.
+  The check can help an administrator quickly identify outdated remoting versions.
+  </p>
+</div>


### PR DESCRIPTION
## [JENKINS-70069](https://issues.jenkins.io/browse/JENKINS-70069) - Add help for remoting version checkbox

[JENKINS-70069](https://issues.jenkins.io/browse/JENKINS-70069) reports that there is no help on the "Remoting Version" checkbox provided by the version node monitors plugin, even though there is help on the JVM version checkbox provided by the plugin.

The help is especially important because users may expect that there is some concept of remoting version compatibility that is included in the check.  See [JENKINS-63607](https://issues.jenkins.io/browse/JENKINS-63607) for an enhancement request asking for such a concept.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue (none provided, interactively verified)

## Screenshot

![remoting-version-help](https://user-images.githubusercontent.com/156685/201485898-c9d464cd-b993-4576-80be-7d4e2a7eb0b9.png)