### PR TITLE
[JENKINS-70074] computer/api results in an error when authenticated

### DIFF
--- a/src/main/java/hudson/plugin/versioncolumn/JVMVersionMonitor.java
+++ b/src/main/java/hudson/plugin/versioncolumn/JVMVersionMonitor.java
@@ -78,7 +78,7 @@ public class JVMVersionMonitor extends NodeMonitor {
 
         if (!isIgnored() && jvmVersionComparator.isNotCompatible()) {
             if (disconnect) {
-                LOGGER.warning(Messages.JVMVersionMonitor_MarkedOffline(c.getName(), CONTROLLER_VERSION, agentVersion));
+                LOGGER.warning(Messages.JVMVersionMonitor_MarkedOffline(c.getName(), CONTROLLER_VERSION, agentVersionStr));
                 ((JvmVersionDescriptor) getDescriptor()).markOffline(c, OfflineCause.create(
                         Messages._JVMVersionMonitor_OfflineCause()));
             } else {
@@ -86,7 +86,7 @@ public class JVMVersionMonitor extends NodeMonitor {
                         "Version incompatibility detected, but keeping the agent '" + c.getName() + "' online per the node monitor configuration");
             }
         }
-        return agentVersion;
+        return agentVersionStr;
     }
 
     public JVMVersionComparator.ComparisonMode getComparisonMode() {


### PR DESCRIPTION
Bug in #91: was returning the rich type instead of the string version. I reproduced JENKINS-70074 as described in the ticket and verified this fixes the bug. CC @MarkEWaite 