### PR TITLE
Test XML result from computer/api/xml end point

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,15 @@
         </dependencies>
     </dependencyManagement>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.modules</groupId>
+            <artifactId>instance-identity</artifactId>
+            <version>116.vf8f487400980</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/src/test/java/hudson/plugin/versioncolumn/RESTAPITest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/RESTAPITest.java
@@ -1,0 +1,55 @@
+package hudson.plugin.versioncolumn;
+
+import com.gargoylesoftware.htmlunit.xml.XmlPage;
+import hudson.model.User;
+import hudson.security.HudsonPrivateSecurityRealm;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.xml.HasXPath.hasXPath;
+
+public class RESTAPITest {
+    @Rule
+    public JenkinsRule rule = new JenkinsRule();
+
+    private final String USER_NAME = "user-for-RESTAPITest";
+
+    private WebClient webClient = null;
+
+    @Before
+    public void setup() throws Exception {
+        final String PASSWORD = "password-for-RESTAPITest";
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
+        rule.jenkins.setSecurityRealm(securityRealm);
+
+        User user = securityRealm.createAccount(USER_NAME, PASSWORD);
+        user.setFullName("User for REST API test");
+        user.save();
+
+        webClient = rule.createWebClient();
+        webClient.login(USER_NAME, PASSWORD);
+   }
+
+    @Test
+    public void securedAPILoginTest() throws Exception {
+        // Check that authnenticated access to the API is allowed
+        XmlPage w1 = (XmlPage) webClient.goTo("whoAmI/api/xml", "application/xml");
+        assertThat(w1, hasXPath("//name", is(USER_NAME)));
+    }
+
+    @Issue("JENKINS-70074")
+    @Test
+    public void securedAPITest() throws Exception {
+        // Interactive testing failed while this automated test did
+        // not fail.  Unclear why they differ. Including this in the
+        // test suite because it may prevent future issues.
+        XmlPage computerApi = (XmlPage) webClient.goTo("computer/api/xml", "application/xml");
+        assertThat(computerApi, hasXPath("//name", is("built-in")));
+    }
+}


### PR DESCRIPTION
[JENKINS-70074](https://issues.jenkins.io/browse/JENKINS-70074) Test XML result from computer/api/xml end point

An unsuccessful attempt to show the failure reported as [JENKINS-70074](https://issues.jenkins.io/browse/JENKINS-70074).  It is unclear to me why interactive testing easily duplicated the failure, while this automated test does not show the failure.

Test would not show the expected error on Linux, but did show the expected error on Windows.  After applying the fix from https://github.com/jenkinsci/versioncolumn-plugin/pull/96, the test passed as expected on both Windows and Linux.

I confirmed with JaCoCo coverage reporting that the method modified in https://github.com/jenkinsci/versioncolumn-plugin/pull/96 is called by this test and was not called by any test before.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
