### PR TITLE
Use `instance-identity` from BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>142.v04572ca_5b_265</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
No need for an explicit version now that this dependency is in the managed set.