### PR TITLE
Rely on artifact caching proxy default setting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,12 +6,9 @@ buildPlugin(
   useContainerAgent: true,
   // Show failures on all configurations
   failFast: false,
-  // Opt-in to the Artifact Caching Proxy, to be removed when it will be opt-out.
-  // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
-  artifactCachingProxyEnabled: true,
   // Test Java 11 with minimum Jenkins version, Java 17 with a more recent version
   configurations: [
     [platform: 'linux',   jdk: '11'], // Linux first for coverage report on ci.jenkins.io
-    [platform: 'windows', jdk: '17', jenkins: '2.387'],
+    [platform: 'windows', jdk: '17', jenkins: '2.389'],
   ]
 )


### PR DESCRIPTION
## Rely on artifact caching proxy default config

The artifact caching proxy is now enabled by default.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
