### PR TITLE
Format code with Palantir Java Format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,12 +106,8 @@
             <!-- define a language-specific format -->
             <java>
               <!-- no need to specify files, inferred automatically -->
-              <!-- apply a specific flavor of google-java-format -->
-              <googleJavaFormat>
-                <version>1.15.0</version>
-                <style>AOSP</style>
-              </googleJavaFormat>
               <endWithNewline />
+              <palantirJavaFormat />
               <removeUnusedImports />
             </java>
             <pom>

--- a/src/main/java/hudson/plugin/versioncolumn/JVMVersionComparator.java
+++ b/src/main/java/hudson/plugin/versioncolumn/JVMVersionComparator.java
@@ -33,16 +33,13 @@ class JVMVersionComparator {
     private boolean compatible;
 
     JVMVersionComparator(
-            Runtime.Version controllerVersion,
-            Runtime.Version agentVersion,
-            ComparisonMode comparisonMode) {
+            Runtime.Version controllerVersion, Runtime.Version agentVersion, ComparisonMode comparisonMode) {
         if (ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE == comparisonMode) {
             compatible = agentVersion.feature() >= controllerVersion.feature();
         } else if (ComparisonMode.EXACT_MATCH == comparisonMode) {
             compatible = controllerVersion.version().equals(agentVersion.version());
         } else if (ComparisonMode.MAJOR_MINOR_MATCH == comparisonMode) {
-            compatible =
-                    compareVersionList(agentVersion.version(), controllerVersion.version()) >= 0;
+            compatible = compareVersionList(agentVersion.version(), controllerVersion.version()) >= 0;
         }
     }
 
@@ -77,8 +74,7 @@ class JVMVersionComparator {
     }
 
     public enum ComparisonMode {
-        RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE(
-                Messages.JVMVersionMonitor_RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE()),
+        RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE(Messages.JVMVersionMonitor_RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE()),
         MAJOR_MINOR_MATCH(Messages.JVMVersionMonitor_MAJOR_MINOR_MATCH()),
         EXACT_MATCH(Messages.JVMVersionMonitor_EXACT_MATCH());
 

--- a/src/main/java/hudson/plugin/versioncolumn/JVMVersionMonitor.java
+++ b/src/main/java/hudson/plugin/versioncolumn/JVMVersionMonitor.java
@@ -47,8 +47,7 @@ public class JVMVersionMonitor extends NodeMonitor {
     private boolean disconnect = true;
 
     @DataBoundConstructor
-    public JVMVersionMonitor(
-            JVMVersionComparator.ComparisonMode comparisonMode, boolean disconnect) {
+    public JVMVersionMonitor(JVMVersionComparator.ComparisonMode comparisonMode, boolean disconnect) {
         this.comparisonMode = comparisonMode;
         this.disconnect = disconnect;
     }
@@ -80,16 +79,13 @@ public class JVMVersionMonitor extends NodeMonitor {
         if (!isIgnored() && jvmVersionComparator.isNotCompatible()) {
             if (disconnect) {
                 LOGGER.warning(
-                        Messages.JVMVersionMonitor_MarkedOffline(
-                                c.getName(), CONTROLLER_VERSION, agentVersionStr));
+                        Messages.JVMVersionMonitor_MarkedOffline(c.getName(), CONTROLLER_VERSION, agentVersionStr));
                 ((JvmVersionDescriptor) getDescriptor())
-                        .markOffline(
-                                c, OfflineCause.create(Messages._JVMVersionMonitor_OfflineCause()));
+                        .markOffline(c, OfflineCause.create(Messages._JVMVersionMonitor_OfflineCause()));
             } else {
-                LOGGER.finer(
-                        "Version incompatibility detected, but keeping the agent '"
-                                + c.getName()
-                                + "' online per the node monitor configuration");
+                LOGGER.finer("Version incompatibility detected, but keeping the agent '"
+                        + c.getName()
+                        + "' online per the node monitor configuration");
             }
         }
         return agentVersionStr;
@@ -102,6 +98,7 @@ public class JVMVersionMonitor extends NodeMonitor {
     @Extension
     public static class JvmVersionDescriptor extends AbstractAsyncNodeMonitorDescriptor<String> {
 
+        @Override
         @NonNull
         public String getDisplayName() {
             return Messages.JVMVersionMonitor_DisplayName();
@@ -119,8 +116,7 @@ public class JVMVersionMonitor extends NodeMonitor {
 
         public ListBoxModel doFillComparisonModeItems() {
             ListBoxModel items = new ListBoxModel();
-            for (JVMVersionComparator.ComparisonMode goal :
-                    JVMVersionComparator.ComparisonMode.values()) {
+            for (JVMVersionComparator.ComparisonMode goal : JVMVersionComparator.ComparisonMode.values()) {
                 items.add(goal.getDescription(), goal.name());
             }
             return items;

--- a/src/main/java/hudson/plugin/versioncolumn/VersionMonitor.java
+++ b/src/main/java/hudson/plugin/versioncolumn/VersionMonitor.java
@@ -53,38 +53,35 @@ public class VersionMonitor extends NodeMonitor {
     }
 
     @Extension
-    public static final AbstractNodeMonitorDescriptor<String> DESCRIPTOR =
-            new AbstractNodeMonitorDescriptor<>() {
+    public static final AbstractNodeMonitorDescriptor<String> DESCRIPTOR = new AbstractNodeMonitorDescriptor<>() {
 
-                protected String monitor(Computer c) throws IOException, InterruptedException {
-                    String version = c.getChannel().call(new SlaveVersion());
-                    if (version == null || !version.equals(masterVersion)) {
-                        if (!isIgnored()) {
-                            markOffline(
-                                    c,
-                                    OfflineCause.create(Messages._VersionMonitor_OfflineCause()));
-                            LOGGER.warning(Messages.VersionMonitor_MarkedOffline(c.getName()));
-                        }
-                    }
-                    return version;
+        protected String monitor(Computer c) throws IOException, InterruptedException {
+            String version = c.getChannel().call(new SlaveVersion());
+            if (version == null || !version.equals(masterVersion)) {
+                if (!isIgnored()) {
+                    markOffline(c, OfflineCause.create(Messages._VersionMonitor_OfflineCause()));
+                    LOGGER.warning(Messages.VersionMonitor_MarkedOffline(c.getName()));
                 }
+            }
+            return version;
+        }
 
-                @NonNull
-                public String getDisplayName() {
-                    return Messages.VersionMonitor_DisplayName();
-                }
+        @NonNull
+        public String getDisplayName() {
+            return Messages.VersionMonitor_DisplayName();
+        }
 
-                @Override
-                public NodeMonitor newInstance(StaplerRequest req, @NonNull JSONObject formData)
-                        throws FormException {
-                    return new VersionMonitor();
-                }
-            };
+        @Override
+        public NodeMonitor newInstance(StaplerRequest req, @NonNull JSONObject formData) throws FormException {
+            return new VersionMonitor();
+        }
+    };
 
     private static final class SlaveVersion extends MasterToSlaveCallable<String, IOException> {
 
         private static final long serialVersionUID = 1L;
 
+        @Override
         public String call() throws IOException {
             try {
                 return Launcher.VERSION;

--- a/src/test/java/hudson/plugin/versioncolumn/JVMVersionComparatorTest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/JVMVersionComparatorTest.java
@@ -29,10 +29,7 @@ public class JVMVersionComparatorTest {
                 true,
             },
             {
-                "17.0.4",
-                "11.0.17",
-                JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE,
-                true,
+                "17.0.4", "11.0.17", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
             },
             {
                 "11.0.17",
@@ -41,10 +38,7 @@ public class JVMVersionComparatorTest {
                 false,
             },
             {
-                "17.0.4",
-                "17.0.4",
-                JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE,
-                true,
+                "17.0.4", "17.0.4", JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, true,
             },
             {
                 "17.0.4",
@@ -147,8 +141,7 @@ public class JVMVersionComparatorTest {
 
     @Test
     public void testGetDescription() {
-        JVMVersionComparator.ComparisonMode object =
-                JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH;
+        JVMVersionComparator.ComparisonMode object = JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH;
         assertEquals(Messages.JVMVersionMonitor_MAJOR_MINOR_MATCH(), object.getDescription());
     }
 

--- a/src/test/java/hudson/plugin/versioncolumn/JVMVersionMonitorTest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/JVMVersionMonitorTest.java
@@ -32,16 +32,14 @@ class JVMVersionMonitorTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void checkDisconnect(
-            JVMVersionComparator.ComparisonMode comparisonMode, boolean disconnect) {
+    public void checkDisconnect(JVMVersionComparator.ComparisonMode comparisonMode, boolean disconnect) {
         JVMVersionMonitor object = new JVMVersionMonitor(comparisonMode, disconnect);
         assertEquals(disconnect, object.isDisconnect());
     }
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void checkComparisonMode(
-            JVMVersionComparator.ComparisonMode comparisonMode, boolean disconnect) {
+    public void checkComparisonMode(JVMVersionComparator.ComparisonMode comparisonMode, boolean disconnect) {
         JVMVersionMonitor object = new JVMVersionMonitor(comparisonMode, disconnect);
         assertEquals(comparisonMode, object.getComparisonMode());
     }

--- a/src/test/java/hudson/plugin/versioncolumn/RESTAPITest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/RESTAPITest.java
@@ -15,7 +15,8 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
 public class RESTAPITest {
-    @Rule public JenkinsRule rule = new JenkinsRule();
+    @Rule
+    public JenkinsRule rule = new JenkinsRule();
 
     private final String USER_NAME = "user-for-RESTAPITest";
 
@@ -24,8 +25,7 @@ public class RESTAPITest {
     @Before
     public void setup() throws Exception {
         final String PASSWORD = "password-for-RESTAPITest";
-        HudsonPrivateSecurityRealm securityRealm =
-                new HudsonPrivateSecurityRealm(false, false, null);
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
         rule.jenkins.setSecurityRealm(securityRealm);
 
         User user = securityRealm.createAccount(USER_NAME, PASSWORD);


### PR DESCRIPTION
Google Java Format is an excellent formatter for 2-space, 100 line codebases. Its [Rectangle Rule](https://github.com/google/google-java-format/wiki/The-Rectangle-Rule) has a high degree of conceptual purity, and this works well in the context of 2-space, 100 line codebases where it was designed. If starting from scratch, or if radical changes to existing code style were on the table, this would be my ideal formatter.

For existing 4-space, 120 line codebases where radical changes to existing code style are not on the table, Google Java Format has some critical flaws. Its 4-space "AOSP" mode does not work well at all, and it was not the primary use case. In practice the combination of 4-space mode and the rectangle rule results in unreadable code for lambdas. I have complained about this on the Google Java Format issue tracker for years, but no fix appears to be on the horizon. This makes sense, because Google internally uses the 2-space non-AOSP mode. While various PRs have been submitted to fix this problem, the maintainers of Google Java Format have rejected or ignored them, likely because they all violate the conceptual purity of the Rectangle Rule.

For existing 4-space, 120 line codebases (and the Jenkins project consists largely of these) where radical changes to existing code style are not on the table, Palantir Java Format is a better choice than Google Java Format. It is a fork of Google Java Format designed for this use case with intentional violations of the Rectangle Rule. In practice it gives much better results than Google Java Format for this type of codebase.

The Maven project is reformatting its legacy codebase with Palantir Java Format and I have been impressed with how relatively uneventful it has been. Palantir Java Format works very well with this type of codebase, and Jenkins is an example of this type of codebase as well. I have successfully reformatted `plugin-compat-tester` this way in https://github.com/jenkinsci/plugin-compat-tester/pull/506 and the results are far better than Google Java Format.

As the Zen of Python states:

> Practicality beats purity.