### PR TITLE
Show documentation on plugins site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <version>${changelist}</version>
   <packaging>hpi</packaging>
   <name>Jenkins Versions Node Monitors plugin</name>
-  <url>https://github.com/${gitHubRepo}</url>
+  <url>https://github.com/jenkinsci/versioncolumn-plugin/blob/master/README.adoc</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
## Show documentation on plugins.jenkins.io

[Current plugin page](https://plugins.jenkins.io/versioncolumn/) does not show documentation

### Testing done

Checked that the URL from the previous release resolved to the repository.  Did not understand why plugins.jenkins.io generator could not find the asciidoc files that documents the plugin.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
