### PR TITLE
Require Jenkins 2.387.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.version>2.375.4</jenkins.version>
+    <jenkins.version>2.387.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>
@@ -69,7 +69,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.375.x</artifactId>
+        <artifactId>bom-2.387.x</artifactId>
         <version>2102.v854b_fec19c92</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## Require Jenkins 2.387.3 or newer

Require Jenkins 2.387.3 or newer so that users do not think that versions older than 2.387.3 are actively tested.

https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/

Choosing a Jenkins version to build against recommends 2.387.3 or 2.375.4 as the base version.  Versions prior to 2.375.4 have known security vulnerabilities in the plugin manager.  I no longer test anything older than 2.387.3.

Over 95% of the most recent plugin release are installed on 2.387.1 or newer.

### Testing done

Regularly tested in my CI environment.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
