### PR TITLE
[JENKINS-63971] prepare for casc support of node monitors

### DIFF
--- a/src/main/java/hudson/plugin/versioncolumn/JVMVersionMonitor.java
+++ b/src/main/java/hudson/plugin/versioncolumn/JVMVersionMonitor.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.security.MasterToSlaveCallable;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class JVMVersionMonitor extends NodeMonitor {
@@ -96,6 +97,7 @@ public class JVMVersionMonitor extends NodeMonitor {
     }
 
     @Extension
+    @Symbol("jvmVersion")
     public static class JvmVersionDescriptor extends AbstractAsyncNodeMonitorDescriptor<String> {
 
         @Override

--- a/src/main/java/hudson/plugin/versioncolumn/VersionMonitor.java
+++ b/src/main/java/hudson/plugin/versioncolumn/VersionMonitor.java
@@ -35,10 +35,8 @@ import hudson.slaves.OfflineCause;
 import java.io.IOException;
 import java.util.logging.Logger;
 import jenkins.security.MasterToSlaveCallable;
-import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
 
 public class VersionMonitor extends NodeMonitor {
 

--- a/src/main/java/hudson/plugin/versioncolumn/VersionMonitor.java
+++ b/src/main/java/hudson/plugin/versioncolumn/VersionMonitor.java
@@ -87,11 +87,6 @@ public class VersionMonitor extends NodeMonitor {
         public String getDisplayName() {
             return Messages.VersionMonitor_DisplayName();
         }
-
-        @Override
-        public NodeMonitor newInstance(StaplerRequest req, @NonNull JSONObject formData) throws FormException {
-            return new VersionMonitor();
-        }
     }
 
     private static final class SlaveVersion extends MasterToSlaveCallable<String, IOException> {

--- a/src/main/java/hudson/plugin/versioncolumn/VersionMonitor.java
+++ b/src/main/java/hudson/plugin/versioncolumn/VersionMonitor.java
@@ -24,6 +24,7 @@
 package hudson.plugin.versioncolumn;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Computer;
@@ -35,11 +36,17 @@ import java.io.IOException;
 import java.util.logging.Logger;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 public class VersionMonitor extends NodeMonitor {
 
     private static final String masterVersion = Launcher.VERSION;
+
+    @DataBoundConstructor
+    public VersionMonitor () {
+    }
 
     @SuppressWarnings("unused") // jelly
     public String toHtml(String version) {
@@ -52,8 +59,17 @@ public class VersionMonitor extends NodeMonitor {
         return version;
     }
 
+    @SuppressFBWarnings(value = "MS_PKGPROTECT", justification = "for backward compatibility")
+    public static /*almost final*/ AbstractNodeMonitorDescriptor<String> DESCRIPTOR;
+
     @Extension
-    public static final AbstractNodeMonitorDescriptor<String> DESCRIPTOR = new AbstractNodeMonitorDescriptor<>() {
+    @Symbol("remotingVersion")
+    public static class DescriptorImpl extends AbstractNodeMonitorDescriptor<String> {
+
+        @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "for backward compatibility")
+        public DescriptorImpl() {
+            DESCRIPTOR = this;
+        }
 
         protected String monitor(Computer c) throws IOException, InterruptedException {
             String version = c.getChannel().call(new SlaveVersion());

--- a/src/main/java/hudson/plugin/versioncolumn/VersionMonitor.java
+++ b/src/main/java/hudson/plugin/versioncolumn/VersionMonitor.java
@@ -45,8 +45,7 @@ public class VersionMonitor extends NodeMonitor {
     private static final String masterVersion = Launcher.VERSION;
 
     @DataBoundConstructor
-    public VersionMonitor () {
-    }
+    public VersionMonitor() {}
 
     @SuppressWarnings("unused") // jelly
     public String toHtml(String version) {
@@ -66,7 +65,9 @@ public class VersionMonitor extends NodeMonitor {
     @Symbol("remotingVersion")
     public static class DescriptorImpl extends AbstractNodeMonitorDescriptor<String> {
 
-        @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "for backward compatibility")
+        @SuppressFBWarnings(
+                value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
+                justification = "for backward compatibility")
         public DescriptorImpl() {
             DESCRIPTOR = this;
         }
@@ -91,7 +92,7 @@ public class VersionMonitor extends NodeMonitor {
         public NodeMonitor newInstance(StaplerRequest req, @NonNull JSONObject formData) throws FormException {
             return new VersionMonitor();
         }
-    };
+    }
 
     private static final class SlaveVersion extends MasterToSlaveCallable<String, IOException> {
 


### PR DESCRIPTION
to support node monitors in casc, is is essential that they have DataBoundConstructors defined and a proper symbol is used.

<!-- Please describe your pull request here. -->

### Testing done
Tested with https://github.com/jenkinsci/configuration-as-code-plugin/pull/2392 that the monitors are properly exported and can be imported.

export looks like this:
```
nodeMonitors:
  - diskSpaceMonitor:
      freeSpaceThreshold: "3GB"
  - tmpSpace:
      freeSpaceThreshold: "3GB"
  - jvmVersion:
      comparisonMode: EXACT_MATCH
      disconnect: true
  - inodesMonitor:
      inodesPercentThreshold: "98%"
  - remotingVersion:
      ignored: true
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
