### PR TITLE
Fix display issue with JVMVersion node monitor

### DIFF
--- a/src/main/java/hudson/plugin/versioncolumn/JVMVersionMonitor.java
+++ b/src/main/java/hudson/plugin/versioncolumn/JVMVersionMonitor.java
@@ -25,6 +25,7 @@ package hudson.plugin.versioncolumn;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.Util;
 import hudson.model.Computer;
 import hudson.node_monitors.AbstractAsyncNodeMonitorDescriptor;
 import hudson.node_monitors.NodeMonitor;
@@ -57,6 +58,14 @@ public class JVMVersionMonitor extends NodeMonitor {
     @SuppressWarnings("unused") // jelly
     public boolean isDisconnect() {
         return disconnect;
+    }
+
+    @SuppressWarnings("unused") // jelly
+    public String toHtml(String version) {
+        if (!version.equals("N/A") && !version.equals(CONTROLLER_VERSION.toString())) {
+            return Util.wrapToErrorSpan(version);
+        }
+        return version;
     }
 
     @Override

--- a/src/main/resources/hudson/plugin/versioncolumn/JVMVersionMonitor/column.jelly
+++ b/src/main/resources/hudson/plugin/versioncolumn/JVMVersionMonitor/column.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
-      <td align="right" data="${data}">${data}</td>
+      <td align="right" data="${data}"><j:out value="${from.toHtml(data)}"/></td>
 </j:jelly>


### PR DESCRIPTION
This is only cosmetic change to be consistent with other monitor. The remoting monitor already used red color when version didn't match

Before

![node_monitor_not_red](https://github.com/jenkinsci/versioncolumn-plugin/assets/825750/f57d2323-5cdd-4312-b1a5-c93cff13e68e)

After

![jvm_nok](https://github.com/jenkinsci/versioncolumn-plugin/assets/825750/df80e77a-e693-4580-af3f-b02e8074af9b)

![JVM_ok](https://github.com/jenkinsci/versioncolumn-plugin/assets/825750/d65862ec-213f-4cb5-b1ad-460a5a9c75b2)

### Testing done

```
mvn hpi:run -Dport=8081 -Dhost=0.0.0.0
```

Create a node and connect with different JVM version

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
