### PR TITLE
JENKINS-63607 Do not disconnect agent when remoting doesn't match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target
 .classpath
 .settings
 .project
+.vscode
 *.iml
 *.ipr
 *.iws

--- a/src/main/resources/hudson/plugin/versioncolumn/VersionMonitor/config.jelly
+++ b/src/main/resources/hudson/plugin/versioncolumn/VersionMonitor/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%DisconnectAgent}" field="disconnect">
+        <f:checkbox />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugin/versioncolumn/VersionMonitor/config.properties
+++ b/src/main/resources/hudson/plugin/versioncolumn/VersionMonitor/config.properties
@@ -1,0 +1,1 @@
+DisconnectAgent=Disconnect agent when remoting mismatch is found

--- a/src/main/resources/hudson/plugin/versioncolumn/VersionMonitor/help-disconnect.html
+++ b/src/main/resources/hudson/plugin/versioncolumn/VersionMonitor/help-disconnect.html
@@ -1,0 +1,6 @@
+<div>
+    <p>Check this checkbox if you want to disconnect agents if they have a mismatch remoting version.
+
+    <p>The default behaviour is to disconnect such agents.</p>
+
+</div>


### PR DESCRIPTION
I'm putting this PR as draft because I have dependency with #189 which change the descriptor to a field and it include some similar changes. Will need to be rebased when merged to main branch

Partially fix JENKINS-63607 to not put the agent offline if there is any mismatch between remoting version

This PR doesn't add any comparison mechanism but only a similar option to not disconnect the agent and keep it online

It also miss some automated test (At least unit for the new field, but I want to check if it's possible to test using  `JenkinsRule` and `DumbSlave`)

### Testing done

- Ensure retro compatibility to disconnect by default (view and when plugin is upgraded)
- Tested with same and different remoting version to ensure correct behavior

The new field 

![version_column_disconnect_remoting](https://github.com/jenkinsci/versioncolumn-plugin/assets/825750/b5095e13-853d-4918-af4b-02d34fe204e7)

The default behavior to disconnect the agent

![remoting_disconnect](https://github.com/jenkinsci/versioncolumn-plugin/assets/825750/43fc49e8-7631-46f4-8cb0-f2843dbe3b2f)

Node is not disconnected with option is selected

![remoting_mismatch_not_disconnect](https://github.com/jenkinsci/versioncolumn-plugin/assets/825750/4f4d52b6-cc7d-447e-9570-9d50dd68d654)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
