### PR TITLE
Display JVM differences with the user-defined JVM comparison mode

### DIFF
--- a/src/main/java/hudson/plugin/versioncolumn/JVMVersionMonitor.java
+++ b/src/main/java/hudson/plugin/versioncolumn/JVMVersionMonitor.java
@@ -62,7 +62,12 @@ public class JVMVersionMonitor extends NodeMonitor {
 
     @SuppressWarnings("unused") // jelly
     public String toHtml(String version) {
-        if (!version.equals("N/A") && !version.equals(CONTROLLER_VERSION.toString())) {
+        if (version == null || version.equals("N/A")) {
+            return "N/A";
+        }
+        final JVMVersionComparator jvmVersionComparator =
+                new JVMVersionComparator(CONTROLLER_VERSION, Runtime.Version.parse(version), comparisonMode);
+        if (jvmVersionComparator.isNotCompatible()) {
             return Util.wrapToErrorSpan(version);
         }
         return version;

--- a/src/test/java/hudson/plugin/versioncolumn/JVMVersionMonitorTest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/JVMVersionMonitorTest.java
@@ -2,6 +2,7 @@ package hudson.plugin.versioncolumn;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -43,4 +44,50 @@ class JVMVersionMonitorTest {
         JVMVersionMonitor object = new JVMVersionMonitor(comparisonMode, disconnect);
         assertEquals(comparisonMode, object.getComparisonMode());
     }
+
+    @Test
+    public void checkToHtmlRendering() throws Exception {
+        
+        JVMVersionMonitor object = new JVMVersionMonitor(JVMVersionComparator.ComparisonMode.EXACT_MATCH, false);
+
+        // N/A
+        assertEquals("N/A", object.toHtml(null));
+        assertEquals("N/A", object.toHtml("N/A"));
+
+        // EXACT_MATCH
+        assertEquals(Runtime.version().toString(), object.toHtml(Runtime.version().toString()));
+        assertEquals(asError("1.1.1.1+1"), object.toHtml("1.1.1.1+1"));
+
+        // RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE
+        object = new JVMVersionMonitor(JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, false);
+        assertEquals(Runtime.version().toString(), object.toHtml(Runtime.version().toString()));
+        assertEquals(majorGreater(), object.toHtml(majorGreater()));
+        assertEquals(majorVersionMatch(), object.toHtml(majorVersionMatch()));
+        assertEquals(asError(majorLower()), object.toHtml(majorLower()));
+
+        // MAJOR_MINOR_MATCH
+        object = new JVMVersionMonitor(JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, false);
+        assertEquals(Runtime.version().toString(), object.toHtml(Runtime.version().toString()));
+        assertEquals(majorGreater(), object.toHtml(majorGreater()));
+        assertEquals(majorVersionMatch(), object.toHtml(majorVersionMatch()));
+        assertEquals(asError(majorLower()), object.toHtml(majorLower()));
+
+    }
+
+    private String majorVersionMatch() {
+        return Runtime.version().feature() + ".99.99.99+99";
+    }
+
+    private String majorLower() {
+        return "1.99.99.99+99";
+    }
+
+    private String majorGreater() {
+        return "999.99.99.99+99";
+    }
+
+    private String asError(String version) {
+        return "<span class=error style='display:inline-block'>" + version + "</span>";
+    }
+
 }

--- a/src/test/java/hudson/plugin/versioncolumn/JVMVersionMonitorTest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/JVMVersionMonitorTest.java
@@ -47,7 +47,7 @@ class JVMVersionMonitorTest {
 
     @Test
     public void checkToHtmlRendering() throws Exception {
-        
+
         JVMVersionMonitor object = new JVMVersionMonitor(JVMVersionComparator.ComparisonMode.EXACT_MATCH, false);
 
         // N/A
@@ -55,23 +55,26 @@ class JVMVersionMonitorTest {
         assertEquals("N/A", object.toHtml("N/A"));
 
         // EXACT_MATCH
-        assertEquals(Runtime.version().toString(), object.toHtml(Runtime.version().toString()));
+        assertEquals(
+                Runtime.version().toString(), object.toHtml(Runtime.version().toString()));
         assertEquals(asError("1.1.1.1+1"), object.toHtml("1.1.1.1+1"));
 
         // RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE
-        object = new JVMVersionMonitor(JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, false);
-        assertEquals(Runtime.version().toString(), object.toHtml(Runtime.version().toString()));
+        object = new JVMVersionMonitor(
+                JVMVersionComparator.ComparisonMode.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE, false);
+        assertEquals(
+                Runtime.version().toString(), object.toHtml(Runtime.version().toString()));
         assertEquals(majorGreater(), object.toHtml(majorGreater()));
         assertEquals(majorVersionMatch(), object.toHtml(majorVersionMatch()));
         assertEquals(asError(majorLower()), object.toHtml(majorLower()));
 
         // MAJOR_MINOR_MATCH
         object = new JVMVersionMonitor(JVMVersionComparator.ComparisonMode.MAJOR_MINOR_MATCH, false);
-        assertEquals(Runtime.version().toString(), object.toHtml(Runtime.version().toString()));
+        assertEquals(
+                Runtime.version().toString(), object.toHtml(Runtime.version().toString()));
         assertEquals(majorGreater(), object.toHtml(majorGreater()));
         assertEquals(majorVersionMatch(), object.toHtml(majorVersionMatch()));
         assertEquals(asError(majorLower()), object.toHtml(majorLower()));
-
     }
 
     private String majorVersionMatch() {
@@ -89,5 +92,4 @@ class JVMVersionMonitorTest {
     private String asError(String version) {
         return "<span class=error style='display:inline-block'>" + version + "</span>";
     }
-
 }


### PR DESCRIPTION
## Display JVM differences with the user-defined JVM comparison mode

This is a minor follow-up of https://github.com/jenkinsci/versioncolumn-plugin/pull/190 that uses configured comparator instead of exact string.

### Testing done

hpi run and one automated test for the `toHtml` method (minimal, just to check the html 

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
