### PR TITLE
Avoid future spotbugs warning with a null check

### DIFF
--- a/src/main/java/hudson/plugin/versioncolumn/VersionMonitor.java
+++ b/src/main/java/hudson/plugin/versioncolumn/VersionMonitor.java
@@ -72,7 +72,11 @@ public class VersionMonitor extends NodeMonitor {
         }
 
         protected String monitor(Computer c) throws IOException, InterruptedException {
-            String version = c.getChannel().call(new SlaveVersion());
+            hudson.remoting.VirtualChannel channel = c.getChannel();
+            if (channel == null) {
+                return "unknown-version";
+            }
+            String version = channel.call(new SlaveVersion());
             if (version == null || !version.equals(masterVersion)) {
                 if (!isIgnored()) {
                     markOffline(c, new RemotingVersionMismatchCause(Messages.VersionMonitor_OfflineCause()));


### PR DESCRIPTION
## Avoid future spotbugs warning with a null check

The Javadoc of the Computer object indicates that if the Computer is online, the return value will never be null. However, it is harmless to avoid the null pointer exception.

### Testing done

Confirmed that automated tests pass.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
