### PR TITLE
[JENKINS-70560] Improve JVMMismatchClause test coverage 

### DIFF
--- a/src/test/java/hudson/plugin/versioncolumn/JVMVersionMonitorTest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/JVMVersionMonitorTest.java
@@ -2,6 +2,7 @@ package hudson.plugin.versioncolumn;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import hudson.node_monitors.NodeMonitor;
 import hudson.util.ListBoxModel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -161,6 +162,20 @@ class JVMVersionMonitorTest {
 
         // Since disconnect is null, isIgnored() should return false (default behavior)
         assertFalse(monitor.isIgnored());
+    }
+
+    @Test
+    public void testGetTrigger() {
+        // Create an instance of JVMVersionMonitor
+        JVMVersionMonitor.JVMMismatchCause monitor = new JVMVersionMonitor.JVMMismatchCause("Test");
+
+        // Call the getTrigger method
+        Class<? extends NodeMonitor> trigger = monitor.getTrigger();
+
+        // Assert that the returned value is not null
+        assertNotNull(trigger, "getTrigger should not be null");
+        // Assert that the returned class is the expected class
+        assertEquals(JVMVersionMonitor.class, trigger, "getTrigger should return JVMVersionMonitor.class");
     }
 
     private String majorVersionMatch() {

--- a/src/test/java/hudson/plugin/versioncolumn/JVMVersionMonitorTest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/JVMVersionMonitorTest.java
@@ -168,6 +168,8 @@ class JVMVersionMonitorTest {
     public void testGetTrigger() {
         // Create an instance of JVMVersionMonitor
         JVMVersionMonitor.JVMMismatchCause monitor = new JVMVersionMonitor.JVMMismatchCause("Test");
+        assertEquals("Test", monitor.toString());
+
 
         // Call the getTrigger method
         Class<? extends NodeMonitor> trigger = monitor.getTrigger();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Improved Test Coverage of JVMVersionMonitor.JVMMismatchCause from 0% to 72%.

Added extensive test coverage for the getTrigger function in the JVMMismatchCause Class of the enclosing JVMVersionMonitor Class. This PR will improve the test coverage of the above said function from 0% to 72%, and overall the entire test coverage of this plugin is improved by 2% from 79% to 81%.

## Before 
![Screenshot (163)](https://github.com/user-attachments/assets/604f0373-0c52-46ec-8775-0cdbcdff7457)
![Screenshot (164)](https://github.com/user-attachments/assets/04096120-9e27-4a0e-ae34-c2fa07d75326)
![Screenshot (162)](https://github.com/user-attachments/assets/d1a1e057-37d7-4170-bf0d-d8f99590b956)

## After
![Screenshot (159)](https://github.com/user-attachments/assets/0340cb35-d1cd-4741-8e37-cfd5782fc83b)
![Screenshot (160)](https://github.com/user-attachments/assets/50f5ac81-4256-4815-93ca-400e64a96940)
![Screenshot (161)](https://github.com/user-attachments/assets/7e17dfaa-ecf1-4625-89c4-21e6de7b6a29)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
