### PR TITLE
[JENKINS-70560] Improve DescriptorImpl test coverage

### DIFF
--- a/src/test/java/hudson/plugin/versioncolumn/VersionMonitorTest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/VersionMonitorTest.java
@@ -113,7 +113,7 @@ public class VersionMonitorTest {
     @Test
     public void testMonitor_DifferentVersion_Ignored() throws IOException, InterruptedException {
         VersionMonitor.DescriptorImpl descriptor = spy(new VersionMonitor.DescriptorImpl());
-        doReturn(true).when(descriptor).isIgnored(); // Ensure isIgnored returns true
+        doReturn(true).when(descriptor).isIgnored(); // Ensure isIgnored returns true.
 
         Computer computer = mock(Computer.class);
         VirtualChannel channel = mock(VirtualChannel.class);

--- a/src/test/java/hudson/plugin/versioncolumn/VersionMonitorTest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/VersionMonitorTest.java
@@ -1,6 +1,10 @@
 package hudson.plugin.versioncolumn;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 import hudson.Util;
@@ -131,7 +135,7 @@ public class VersionMonitorTest {
     }
 
     @Test
-    public void testMonitor_VersionIsNull() throws IOException, InterruptedException {
+    public void testMonitor_VersionIsNull_NotIgnored() throws IOException, InterruptedException {
         VersionMonitor.DescriptorImpl descriptor = spy(new VersionMonitor.DescriptorImpl());
         doReturn(false).when(descriptor).isIgnored(); // Ensure isIgnored returns false
 
@@ -148,6 +152,27 @@ public class VersionMonitorTest {
 
         assertNull(result);
         verify(computer).setTemporarilyOffline(eq(true), any(VersionMonitor.RemotingVersionMismatchCause.class));
+    }
+
+    @Test
+    public void testMonitor_VersionIsNull_Ignored() throws IOException, InterruptedException {
+        VersionMonitor.DescriptorImpl descriptor = spy(new VersionMonitor.DescriptorImpl());
+        doReturn(true).when(descriptor).isIgnored(); // Ensure isIgnored returns true.
+
+        Computer computer = mock(Computer.class);
+        VirtualChannel channel = mock(VirtualChannel.class);
+        VersionMonitor.RemotingVersionMismatchCause cause = mock(VersionMonitor.RemotingVersionMismatchCause.class);
+
+        when(computer.getChannel()).thenReturn(channel);
+        when(channel.call(ArgumentMatchers.<MasterToSlaveCallable<String, IOException>>any()))
+                .thenReturn(null);
+        when(computer.isOffline()).thenReturn(true);
+        when(computer.getOfflineCause()).thenReturn(cause);
+
+        String result = descriptor.monitor(computer);
+
+        assertNull(result);
+        verify(computer).setTemporarilyOffline(eq(false), isNull());
     }
 
     @Test


### PR DESCRIPTION
## JENKINS-70560 Improve DescriptorImpl test coverage

Improve test coverage of DescriptorImpl.

### Testing done

Improved test coverage of DescriptorImpl by adding testMonitor_VersionIsNull_Ignored and modifying the existing testMonitor_VersionIsNull to testMonitor_VersionIsNull_NotIgnored. These changes cover both the cases where isIgnored is true and false respectively, and version is null.
Result - Test Coverage of DescriptorImpl improved from 86% to 100%. Overall plugin coverage improved from 81% to 83%.


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
