### PR TITLE
Remove brittle tests, simplify VersionMonitorTest

### DIFF
--- a/src/test/java/hudson/plugin/versioncolumn/VersionMonitorTest.java
+++ b/src/test/java/hudson/plugin/versioncolumn/VersionMonitorTest.java
@@ -1,123 +1,96 @@
 package hudson.plugin.versioncolumn;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
+import hudson.Proc;
 import hudson.Util;
 import hudson.model.Computer;
 import hudson.remoting.Launcher;
 import hudson.remoting.VirtualChannel;
+import hudson.slaves.DumbSlave;
 import hudson.slaves.OfflineCause;
 import java.io.IOException;
 import jenkins.security.MasterToSlaveCallable;
+import jenkins.slaves.RemotingVersionInfo;
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.jvnet.hudson.test.FakeLauncher;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.PretendSlave;
 import org.mockito.ArgumentMatchers;
 
 public class VersionMonitorTest {
 
-    @Test
-    public void testConstructor() {
-        VersionMonitor versionMonitor = new VersionMonitor();
-        assertNotNull("VersionMonitor instance should not be null", versionMonitor);
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    private VersionMonitor versionMonitor;
+    private VersionMonitor.DescriptorImpl descriptor;
+
+    @Before
+    public void createVersionMonitor() {
+        versionMonitor = new VersionMonitor();
+        descriptor = (VersionMonitor.DescriptorImpl) versionMonitor.getDescriptor();
     }
 
     @Test
     public void testToHtml_NullVersion() {
-        VersionMonitor versionMonitor = new VersionMonitor();
-        String result = versionMonitor.toHtml(null);
-        assertEquals("N/A", result);
+        assertEquals("N/A", versionMonitor.toHtml(null));
     }
 
     @Test
     public void testToHtml_SameVersion() {
-        VersionMonitor versionMonitor = new VersionMonitor();
-        String version = Launcher.VERSION;
-        String result = versionMonitor.toHtml(version);
-        assertEquals(version, result);
+        String remotingVersion = RemotingVersionInfo.getEmbeddedVersion().toString();
+        assertEquals(Launcher.VERSION, remotingVersion);
+        assertEquals(Launcher.VERSION, versionMonitor.toHtml(remotingVersion));
     }
 
     @Test
     public void testToHtml_DifferentVersion() {
-        VersionMonitor versionMonitor = new VersionMonitor();
-        String version = "different-version";
-        String result = versionMonitor.toHtml(version);
-        String expected = Util.wrapToErrorSpan(version);
-        assertEquals(expected, result);
+        String version = RemotingVersionInfo.getMinimumSupportedVersion().toString();
+        assertEquals(Util.wrapToErrorSpan(version), versionMonitor.toHtml(version));
     }
 
     @Test
     public void testDescriptorImplConstructor() {
-        VersionMonitor.DescriptorImpl descriptor = new VersionMonitor.DescriptorImpl();
-        assertNotNull("DescriptorImpl instance should not be null", descriptor);
-        assertSame("DESCRIPTOR should be set to this instance", VersionMonitor.DESCRIPTOR, descriptor);
+        VersionMonitor.DescriptorImpl descriptorImpl = new VersionMonitor.DescriptorImpl();
+        assertSame("DESCRIPTOR should be set to this instance", VersionMonitor.DESCRIPTOR, descriptorImpl);
     }
 
     @Test
     public void testGetDisplayName() {
-        VersionMonitor.DescriptorImpl descriptor = new VersionMonitor.DescriptorImpl();
-        String displayName = descriptor.getDisplayName();
-        assertNotNull("Display name should not be null", displayName);
+        assertEquals("Remoting Version", descriptor.getDisplayName());
     }
 
     @Test
-    public void testMonitor_NullChannel() throws IOException, InterruptedException {
-        VersionMonitor.DescriptorImpl descriptor = new VersionMonitor.DescriptorImpl();
-        Computer computer = mock(Computer.class);
-
-        when(computer.getChannel()).thenReturn(null);
-
-        String result = descriptor.monitor(computer);
-
-        assertEquals("unknown-version", result);
-        verify(computer, never()).setTemporarilyOffline(anyBoolean(), any());
+    public void testMonitor_NullChannel() throws Exception {
+        PretendSlave pretendAgent = j.createPretendSlave(new TestLauncher());
+        Computer computer = pretendAgent.createComputer();
+        assertNull(computer.getChannel()); // Pre-condition for next assertion
+        assertEquals("unknown-version", descriptor.monitor(computer));
     }
 
     @Test
-    public void testMonitor_SameVersion() throws IOException, InterruptedException {
-        VersionMonitor.DescriptorImpl descriptor = new VersionMonitor.DescriptorImpl();
-        Computer computer = mock(Computer.class);
-        VirtualChannel channel = mock(VirtualChannel.class);
-
-        when(computer.getChannel()).thenReturn(channel);
-        when(channel.call(ArgumentMatchers.<MasterToSlaveCallable<String, IOException>>any()))
-                .thenReturn(Launcher.VERSION);
-        when(computer.isOffline()).thenReturn(false);
-
-        String result = descriptor.monitor(computer);
-
-        assertEquals(Launcher.VERSION, result);
-        verify(computer, never()).setTemporarilyOffline(anyBoolean(), any());
-    }
-
-    @Test
-    public void testMonitor_DifferentVersion_NotIgnored() throws IOException, InterruptedException {
-        VersionMonitor.DescriptorImpl descriptor = spy(new VersionMonitor.DescriptorImpl());
-        doReturn(false).when(descriptor).isIgnored(); // Ensure isIgnored returns false
-
-        Computer computer = mock(Computer.class);
-        VirtualChannel channel = mock(VirtualChannel.class);
-        String differentVersion = "different-version";
-
-        when(computer.getChannel()).thenReturn(channel);
-        when(channel.call(ArgumentMatchers.<MasterToSlaveCallable<String, IOException>>any()))
-                .thenReturn(differentVersion);
-        when(computer.isOffline()).thenReturn(false);
-        when(computer.getName()).thenReturn("TestComputer");
-
-        String result = descriptor.monitor(computer);
-
-        assertEquals(differentVersion, result);
-        verify(computer).setTemporarilyOffline(eq(true), any(VersionMonitor.RemotingVersionMismatchCause.class));
+    public void testMonitor_SameVersion() throws Exception {
+        DumbSlave agent = j.createOnlineSlave();
+        Computer computer = agent.getComputer();
+        assertNotNull(computer.getChannel());
+        assertEquals(Launcher.VERSION, descriptor.monitor(computer));
     }
 
     @Test
     public void testMonitor_DifferentVersion_Ignored() throws IOException, InterruptedException {
-        VersionMonitor.DescriptorImpl descriptor = spy(new VersionMonitor.DescriptorImpl());
-        doReturn(true).when(descriptor).isIgnored(); // Ensure isIgnored returns true.
+        VersionMonitor.DescriptorImpl mockDescriptor = spy(new VersionMonitor.DescriptorImpl());
+        doReturn(true).when(mockDescriptor).isIgnored(); // Ensure isIgnored returns true.
 
         Computer computer = mock(Computer.class);
         VirtualChannel channel = mock(VirtualChannel.class);
@@ -128,36 +101,16 @@ public class VersionMonitorTest {
                 .thenReturn(differentVersion);
         when(computer.isOffline()).thenReturn(false);
 
-        String result = descriptor.monitor(computer);
+        String result = mockDescriptor.monitor(computer);
 
         assertEquals(differentVersion, result);
         verify(computer, never()).setTemporarilyOffline(anyBoolean(), any());
     }
 
     @Test
-    public void testMonitor_VersionIsNull_NotIgnored() throws IOException, InterruptedException {
-        VersionMonitor.DescriptorImpl descriptor = spy(new VersionMonitor.DescriptorImpl());
-        doReturn(false).when(descriptor).isIgnored(); // Ensure isIgnored returns false
-
-        Computer computer = mock(Computer.class);
-        VirtualChannel channel = mock(VirtualChannel.class);
-
-        when(computer.getChannel()).thenReturn(channel);
-        when(channel.call(ArgumentMatchers.<MasterToSlaveCallable<String, IOException>>any()))
-                .thenReturn(null);
-        when(computer.isOffline()).thenReturn(false);
-        when(computer.getName()).thenReturn("TestComputer");
-
-        String result = descriptor.monitor(computer);
-
-        assertNull(result);
-        verify(computer).setTemporarilyOffline(eq(true), any(VersionMonitor.RemotingVersionMismatchCause.class));
-    }
-
-    @Test
     public void testMonitor_VersionIsNull_Ignored() throws IOException, InterruptedException {
-        VersionMonitor.DescriptorImpl descriptor = spy(new VersionMonitor.DescriptorImpl());
-        doReturn(true).when(descriptor).isIgnored(); // Ensure isIgnored returns true.
+        VersionMonitor.DescriptorImpl mockDescriptor = spy(new VersionMonitor.DescriptorImpl());
+        doReturn(true).when(mockDescriptor).isIgnored(); // Ensure isIgnored returns true.
 
         Computer computer = mock(Computer.class);
         VirtualChannel channel = mock(VirtualChannel.class);
@@ -169,7 +122,7 @@ public class VersionMonitorTest {
         when(computer.isOffline()).thenReturn(true);
         when(computer.getOfflineCause()).thenReturn(cause);
 
-        String result = descriptor.monitor(computer);
+        String result = mockDescriptor.monitor(computer);
 
         assertNull(result);
         verify(computer).setTemporarilyOffline(eq(false), isNull());
@@ -177,7 +130,6 @@ public class VersionMonitorTest {
 
     @Test
     public void testMonitor_OfflineDueToMismatch_VersionsMatch() throws IOException, InterruptedException {
-        VersionMonitor.DescriptorImpl descriptor = new VersionMonitor.DescriptorImpl();
         Computer computer = mock(Computer.class);
         VirtualChannel channel = mock(VirtualChannel.class);
         VersionMonitor.RemotingVersionMismatchCause cause = new VersionMonitor.RemotingVersionMismatchCause("Mismatch");
@@ -196,7 +148,6 @@ public class VersionMonitorTest {
 
     @Test
     public void testMonitor_OfflineDueToOtherCause() throws IOException, InterruptedException {
-        VersionMonitor.DescriptorImpl descriptor = new VersionMonitor.DescriptorImpl();
         Computer computer = mock(Computer.class);
         VirtualChannel channel = mock(VirtualChannel.class);
         OfflineCause otherCause = mock(OfflineCause.class);
@@ -222,6 +173,11 @@ public class VersionMonitorTest {
         assertEquals(VersionMonitor.class, cause.getTrigger());
     }
 
-    // Since SlaveVersion is private, we cannot test it directly.
-    // However, we can test its behavior indirectly through the monitor method.
+    private class TestLauncher implements FakeLauncher {
+
+        @Override
+        public Proc onLaunch(hudson.Launcher.ProcStarter p) throws IOException {
+            throw new UnsupportedOperationException("Unsupported run.");
+        }
+    }
 }


### PR DESCRIPTION
## Remove brittle tests, simplify VersionMonitorTest

Delete two brittle tests.  Jenkins 2.482 includes improvements that break the implementation assumptions embedded in the mocking used by the tests.  Remove the tests rather than fight with the brittleness.  Causes a minimal reduction in test coverage.

Replace mocking in a few tests with objects provided by Jenkins core.

Use actual remoting versions in the tests.

### Testing done

Confirmed that new tests pass with Jenkins 2.479.1 through Jenkins 2.493.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
