### PR TITLE
Use parent pom 5.2099.v68c2f5e27299

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.2098.v4d48a_c4c68e7</version>
+    <version>5.2099.v68c2f5e27299</version>
     <relativePath />
   </parent>
 

--- a/src/main/resources/hudson/plugin/versioncolumn/JVMVersionMonitor/config_de.properties
+++ b/src/main/resources/hudson/plugin/versioncolumn/JVMVersionMonitor/config_de.properties
@@ -1,2 +1,2 @@
 ComparisonTitle=Vergleichsmodus von Agent- und Controller-JVMs
-DisconnectAgent=Agent trennen, wenn eine Inkompatibilit\u00e4t festgestellt wird
+DisconnectAgent=Agent trennen, wenn eine Inkompatibilität festgestellt wird

--- a/src/main/resources/hudson/plugin/versioncolumn/Messages_de.properties
+++ b/src/main/resources/hudson/plugin/versioncolumn/Messages_de.properties
@@ -1,12 +1,12 @@
 VersionMonitor.DisplayName=Remoting Version
 VersionMonitor.OfflineCause=Dieser Knoten ist offline, weil er ein altes agent.jar verwendet
-VersionMonitor.MarkedOffline=Setze {0} vor\u00fcbergehend offline aufgrund der Verwendung einer alten agent.jar
+VersionMonitor.MarkedOffline=Setze {0} vorübergehend offline aufgrund der Verwendung einer alten agent.jar
 
 JVMVersionMonitor.DisplayName=JVM Version
 JVMVersionMonitor.OfflineCause=Dieser Knoten ist offline, weil die JVM-Version des Agenten inkompatibel mit der des Controllers ist.
-JVMVersionMonitor.MarkedOffline=Vor\u00fcbergehende Offline-Schaltung von {0} aufgrund der Verwendung einer inkompatiblen JVM-Version zwischen Agent und Controller (Controller={1}, Agent={2})
-JVMVersionMonitor.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE=Der Agent muss eine JVM verwenden, deren Feature-Release-Z\u00e4hler (z.B. 11 oder 17) gr\u00f6\u00dfer oder gleich dem des Controllers ist (dringend empfohlenes Minimum).
-JVMVersionMonitor.MAJOR_MINOR_MATCH=Der Agent muss eine JVM ausf\u00fchren, deren Versionsnummer (z. B. 11.0.17 oder 17.0.12.1) gr\u00f6\u00dfer oder gleich der des Controllers ist (Paranoid-Version)
-JVMVersionMonitor.EXACT_MATCH=Der Agent muss eine JVM ausf\u00fchren, deren Versionsnummer (z.B. 11.0.17 oder 17.0.12.1) mit der des Controllers \u00fcbereinstimmt (Paranoid++-Version)
+JVMVersionMonitor.MarkedOffline=Vorübergehende Offline-Schaltung von {0} aufgrund der Verwendung einer inkompatiblen JVM-Version zwischen Agent und Controller (Controller={1}, Agent={2})
+JVMVersionMonitor.RUNTIME_GREATER_OR_EQUAL_MASTER_BYTECODE=Der Agent muss eine JVM verwenden, deren Feature-Release-Zähler (z.B. 11 oder 17) größer oder gleich dem des Controllers ist (dringend empfohlenes Minimum).
+JVMVersionMonitor.MAJOR_MINOR_MATCH=Der Agent muss eine JVM ausführen, deren Versionsnummer (z. B. 11.0.17 oder 17.0.12.1) größer oder gleich der des Controllers ist (Paranoid-Version)
+JVMVersionMonitor.EXACT_MATCH=Der Agent muss eine JVM ausführen, deren Versionsnummer (z.B. 11.0.17 oder 17.0.12.1) mit der des Controllers übereinstimmt (Paranoid++-Version)
 
-JVMVersionMonitor.UnrecognizedAgentJVM=Die Agent-JVM-Version {0} wird vom Plugin nicht erkannt. Sie sollten ein Ticket f\u00fcr den Maintainer \u00f6ffnen, um die Kompatibilit\u00e4tsliste zu vervollst\u00e4ndigen.
+JVMVersionMonitor.UnrecognizedAgentJVM=Die Agent-JVM-Version {0} wird vom Plugin nicht erkannt. Sie sollten ein Ticket für den Maintainer öffnen, um die Kompatibilitätsliste zu vervollständigen.


### PR DESCRIPTION
## Use parent pom 5.2099.v68c2f5e27299

Also reverts the change to the properties file from the previous parent pom update in ecf6cf7c1c872a4345a98e23e70ed80989f170bc, pull request:

* https://github.com/jenkinsci/versioncolumn-plugin/pull/388

### Testing done

Confirmed that `mvn verify` still passes, even with the UTF-8 properties file.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
